### PR TITLE
Tweak epoch_range response

### DIFF
--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -137,12 +137,11 @@ macro_rules! field_range {
         let epoch_range = $self.epoch_range($start_epoch, $end_epoch);
         epoch_range
             .iter()
-            .map(|entry| {
-                if entry.$field != ValidatorHistoryEntry::default().$field {
-                    Some(entry.$field)
-                } else {
-                    None
-                }
+            .map(|option_entry| {
+                option_entry
+                    .as_ref()
+                    .map(|entry| entry.$field)
+                    .filter(|&field| field != ValidatorHistoryEntry::default().$field)
             })
             .collect::<Vec<Option<$type>>>()
     }};
@@ -181,12 +180,27 @@ impl CircBuf {
 
     /// Returns &ValidatorHistoryEntry for each existing entry in range [start_epoch, end_epoch], factoring for wraparound
     /// Returns None if either start_epoch or end_epoch is not in the CircBuf
-    pub fn epoch_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<&ValidatorHistoryEntry> {
+    pub fn epoch_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<&ValidatorHistoryEntry>> {
         // creates an iterator that lays out the entries in consecutive order, handling wraparound
-        self.arr[(self.idx as usize + 1)..] // if self.idx + 1 == self.arr.len() this will just return an empty slice
+        let mut entries = self.arr[(self.idx as usize + 1)..] // if self.idx + 1 == self.arr.len() this will just return an empty slice
             .iter()
             .chain(self.arr[..=(self.idx as usize)].iter())
             .filter(|entry| entry.epoch >= start_epoch && entry.epoch <= end_epoch)
+            .peekable();
+        (start_epoch..=end_epoch)
+            .map(|epoch| {
+                if let Some(&entry) = entries.peek() {
+                    if entry.epoch == epoch {
+                        entries.next();
+                        return Some(entry);
+                    }
+                }
+                None
+            })
             .collect()
     }
 
@@ -674,9 +688,12 @@ mod tests {
             circ_buf.push(entry);
         }
         // Test epoch range [0, 3]
-        let epoch_range: Vec<&ValidatorHistoryEntry> = circ_buf.epoch_range(0, 3);
+        let epoch_range: Vec<Option<&ValidatorHistoryEntry>> = circ_buf.epoch_range(0, 3);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
+            epoch_range
+                .iter()
+                .filter_map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<u16>>(),
             vec![0, 1, 2, 3]
         );
 
@@ -696,29 +713,41 @@ mod tests {
         // Test epoch range [0, 3]
         let epoch_range = circ_buf.epoch_range(0, 3);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
-            vec![0, 1, 3]
+            epoch_range
+                .iter()
+                .map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<Option<u16>>>(),
+            vec![Some(0), Some(1), None, Some(3)]
         );
 
         // same start and end epoch
         // Test end epoch out of range
         let epoch_range = circ_buf.epoch_range(0, 5);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
-            vec![0, 1, 3]
+            epoch_range
+                .iter()
+                .map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<Option<u16>>>(),
+            vec![Some(0), Some(1), None, Some(3), None, None]
         );
 
         // None if start epoch is none
         let epoch_range = circ_buf.epoch_range(2, 3);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
-            vec![3]
+            epoch_range
+                .iter()
+                .map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<Option<u16>>>(),
+            vec![None, Some(3)]
         );
 
         let epoch_range = circ_buf.epoch_range(3, 3);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
-            vec![3]
+            epoch_range
+                .iter()
+                .map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<Option<u16>>>(),
+            vec![Some(3)]
         );
 
         let epoch_range = circ_buf.epoch_range(4, 3);
@@ -736,7 +765,10 @@ mod tests {
         let epoch_range =
             circ_buf.epoch_range(circ_buf.arr.len() as u16 - 4, circ_buf.arr.len() as u16 + 4);
         assert_eq!(
-            epoch_range.iter().map(|e| e.epoch).collect::<Vec<u16>>(),
+            epoch_range
+                .iter()
+                .filter_map(|maybe_e| maybe_e.map(|e| e.epoch))
+                .collect::<Vec<u16>>(),
             vec![508, 509, 510, 511, 512, 513, 514, 515, 516]
         );
     }


### PR DESCRIPTION
Tweaks epoch_range response so it's easier to align the output from different objects and guarantee that the epochs will be aligned
