### PR TITLE
Improve Keeper Reliability

### DIFF
--- a/keepers/keeper-core/src/lib.rs
+++ b/keepers/keeper-core/src/lib.rs
@@ -23,6 +23,7 @@ pub struct SubmitStats {
     pub successes: u64,
     pub errors: u64,
 }
+
 #[derive(Debug, Default, Clone, Copy)]
 pub struct CreateUpdateStats {
     pub creates: SubmitStats,
@@ -524,10 +525,6 @@ pub async fn submit_instructions(
                 TransactionExecutionError::ClientError(_, instructions) => instructions.len(),
                 TransactionExecutionError::TransactionClientError(_, instructions) => {
                     instructions.concat().len()
-                }
-                _ => {
-                    error!("Hit unreachable statement in submit_instructions");
-                    unreachable!();
                 }
             };
             stats.successes = num_instructions as u64 - instructions_len as u64;

--- a/keepers/keeper-core/src/lib.rs
+++ b/keepers/keeper-core/src/lib.rs
@@ -18,13 +18,13 @@ use solana_sdk::{
 use thiserror::Error as ThisError;
 use tokio::task::{self, JoinError};
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct SubmitStats {
     pub successes: u64,
     pub errors: u64,
+    pub results: Vec<Result<(), SendTransactionError>>,
 }
-
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone)]
 pub struct CreateUpdateStats {
     pub creates: SubmitStats,
     pub updates: SubmitStats,
@@ -33,12 +33,10 @@ pub struct CreateUpdateStats {
 pub type Error = Box<dyn std::error::Error>;
 #[derive(ThisError, Debug, Clone)]
 pub enum TransactionExecutionError {
-    #[error("Transactions failed to execute after multiple retries")]
-    TransactionRetryError(Vec<(Vec<Instruction>, String)>),
     #[error("RPC Client error: {0:?}")]
-    ClientError(String, Vec<Instruction>),
+    ClientError(String),
     #[error("RPC Client error: {0:?}")]
-    TransactionClientError(String, Vec<Vec<Instruction>>),
+    TransactionClientError(String, Vec<Result<(), SendTransactionError>>),
 }
 
 pub const NOT_CONFIRMED_MESSAGE: &str = "Transaction failed to confirm after multiple retries";
@@ -200,85 +198,11 @@ async fn calculate_instructions_per_tx(
     Ok(size_max.min(compute_max))
 }
 
-async fn parallel_submit_transactions(
-    client: &RpcClient,
-    signer: &Arc<Keypair>,
-    // Each &[Instruction] represents a transaction
-    transactions: &[&[Instruction]],
-) -> Result<(HashMap<Signature, usize>, HashMap<usize, String>), TransactionExecutionError> {
-    // Converts arrays of instructions into transactions and submits them in parallel, in batches of 50 (arbitrary, to avoid spamming RPC)
-    // Saves signatures associated with the indexes of instructions it contains. Drops transactions that fail simulation, unless the error is BlockhashNotFound
-    // Returns a hashmap of executed signatures and their indexes, and a hashmap of errors and their indexes
-
-    let mut executed_signatures: HashMap<Signature, usize> = HashMap::new();
-    let mut error_messages: HashMap<usize, String> = HashMap::new();
-
-    const TX_BATCH_SIZE: usize = 50;
-    for (batch_num, transaction_batch) in transactions.chunks(TX_BATCH_SIZE).enumerate() {
-        let index_offset = TX_BATCH_SIZE * batch_num;
-        let recent_blockhash = get_latest_blockhash_with_retry(client).await.map_err(|e| {
-            TransactionExecutionError::TransactionClientError(
-                e.to_string(),
-                transactions.iter().map(|&tx| tx.to_vec()).collect(),
-            )
-        })?;
-        // Convert instructions to transactions in batches and send them all, saving their signatures
-        let submitted_transactions: Vec<Transaction> = transaction_batch
-            .iter()
-            .map(|batch| {
-                Transaction::new_signed_with_payer(
-                    batch,
-                    Some(&signer.pubkey()),
-                    &[signer.as_ref()],
-                    recent_blockhash,
-                )
-            })
-            .collect();
-
-        let tx_futures = submitted_transactions
-            .iter()
-            .map(|tx| async move { client.send_transaction(tx).await })
-            .collect::<Vec<_>>();
-
-        let results = futures::future::join_all(tx_futures).await;
-        for (i, result) in results.into_iter().enumerate() {
-            match result {
-                Ok(signature) => {
-                    executed_signatures.insert(signature, i + index_offset);
-                }
-                Err(e) => {
-                    match e.get_transaction_error() {
-                        // If blockhash not found, transaction is still valid and should not be dropped
-                        Some(TransactionError::BlockhashNotFound) => {
-                            executed_signatures
-                                .insert(submitted_transactions[i].signatures[0], i + index_offset);
-                        }
-                        // If another error is returned, transaction probably won't succeed on retries
-                        Some(_) | None => {
-                            let message = e.to_string();
-                            warn!("Transaction failed: {:?}", e);
-                            error_messages.insert(i + index_offset, message);
-                        }
-                    }
-                }
-            }
-        }
-
-        debug!(
-            "Transactions sent: {}, executed_signatures: {}",
-            submitted_transactions.len(),
-            executed_signatures.len()
-        );
-    }
-
-    Ok((executed_signatures, error_messages))
-}
-
 async fn parallel_confirm_transactions(
     client: &RpcClient,
-    mut executed_signatures: HashMap<Signature, usize>,
+    executed_signatures: HashMap<Signature, usize>,
 ) -> HashMap<Signature, usize> {
-    // Confirmes TXs in batches of 256 (max allowed by RPC method)
+    // Confirmes TXs in batches of 256 (max allowed by RPC method). Returns confirmed signatures
     const SIG_STATUS_BATCH_SIZE: usize = 256;
     let signatures_to_confirm = executed_signatures.clone().into_keys().collect::<Vec<_>>();
 
@@ -302,11 +226,12 @@ async fn parallel_confirm_transactions(
     let results = futures::future::join_all(confirmation_futures).await;
 
     let num_transactions_submitted = executed_signatures.len();
+    let mut confirmed_signatures: HashMap<Signature, usize> = HashMap::new();
     for result_batch in results.iter() {
         for (sig, result) in result_batch {
             if let Some(status) = result {
                 if status.satisfies_commitment(client.commitment()) && status.err.is_none() {
-                    executed_signatures.remove(sig);
+                    confirmed_signatures.insert(*sig, executed_signatures[sig]);
                 }
             }
         }
@@ -315,18 +240,115 @@ async fn parallel_confirm_transactions(
     info!(
         "{} transactions submitted, {} confirmed",
         num_transactions_submitted,
-        num_transactions_submitted - executed_signatures.len()
+        confirmed_signatures.len()
     );
-    executed_signatures.clone()
+    confirmed_signatures.clone()
+}
+
+async fn sign_txs(
+    client: &Arc<RpcClient>,
+    transactions: &[&[Instruction]],
+    signer: &Arc<Keypair>,
+) -> Result<Vec<Transaction>, ClientError> {
+    let blockhash = get_latest_blockhash_with_retry(client).await?;
+
+    let signed_txs = transactions
+        .into_iter()
+        .map(|instructions| {
+            Transaction::new_signed_with_payer(
+                instructions,
+                Some(&signer.pubkey()),
+                &[signer.as_ref()],
+                blockhash,
+            )
+        })
+        .collect();
+
+    Ok(signed_txs)
+}
+
+#[derive(Clone, Debug)]
+pub enum SendTransactionError {
+    ExceededRetries,
+    // Stores ClientError.to_string(), since ClientError does not impl Clone, and we want to track both
+    // io/reqwest errors as well as transaction errors
+    TransactionError(String),
+}
+
+pub async fn parallel_execute_transactions(
+    client: &Arc<RpcClient>,
+    transactions: &[&[Instruction]],
+    signer: &Arc<Keypair>,
+    retry_count: u16,
+    confirmation_time: u64,
+) -> Result<Vec<Result<(), SendTransactionError>>, TransactionExecutionError> {
+    let mut results = vec![Err(SendTransactionError::ExceededRetries); transactions.len()];
+    let mut retries = 0;
+
+    if transactions.is_empty() {
+        return Ok(results);
+    }
+
+    let mut signed_txs = sign_txs(client, transactions, signer)
+        .await
+        .map_err(|e| TransactionExecutionError::ClientError(e.to_string()))?;
+
+    while retries < retry_count {
+        let mut submitted_signatures = HashMap::new();
+
+        for (idx, tx) in signed_txs.iter().enumerate() {
+            if results[idx].is_ok() {
+                continue;
+            }
+
+            // Future optimization: submit these in parallel batches and refresh blockhash for every batch
+            match client.send_transaction(tx).await {
+                Ok(signature) => {
+                    submitted_signatures.insert(signature, idx);
+                }
+                Err(e) => match e.get_transaction_error() {
+                    Some(TransactionError::BlockhashNotFound)
+                    | Some(TransactionError::AlreadyProcessed) => {
+                        submitted_signatures.insert(tx.signatures[0], idx);
+                    }
+                    Some(_) | None => {
+                        warn!("Transaction error: {}", e.to_string());
+                        results[idx] = Err(SendTransactionError::TransactionError(e.to_string()))
+                    }
+                },
+            }
+        }
+
+        tokio::time::sleep(Duration::from_secs(confirmation_time)).await;
+
+        for idx in parallel_confirm_transactions(client, submitted_signatures)
+            .await
+            .into_values()
+        {
+            results[idx] = Ok(());
+        }
+
+        if results.iter().all(|r| r.is_ok()) {
+            break;
+        }
+
+        // Re-sign transactions with fresh blockhash
+        signed_txs = sign_txs(client, transactions, signer).await.map_err(|e| {
+            TransactionExecutionError::TransactionClientError(e.to_string(), results.clone())
+        })?;
+        retries += 1;
+    }
+
+    Ok(results)
 }
 
 pub async fn parallel_execute_instructions(
     client: &Arc<RpcClient>,
-    instructions: Vec<Instruction>,
+    instructions: &[Instruction],
     signer: &Arc<Keypair>,
     retry_count: u16,
     confirmation_time: u64,
-) -> Result<(), TransactionExecutionError> {
+) -> Result<Vec<Result<(), SendTransactionError>>, TransactionExecutionError> {
     /*
         Note: Assumes all instructions are equivalent in compute, equivalent in size, and can be executed in any order
 
@@ -339,97 +361,22 @@ pub async fn parallel_execute_instructions(
     */
 
     if instructions.is_empty() {
-        return Ok(());
+        return Ok(vec![]);
     }
 
     let instructions_per_tx = calculate_instructions_per_tx(client, &instructions, signer)
         .await
-        .map_err(|e| {
-            TransactionExecutionError::ClientError(e.to_string(), instructions.to_vec())
-        })?;
+        .map_err(|e| TransactionExecutionError::ClientError(e.to_string()))?;
     let transactions: Vec<&[Instruction]> = instructions.chunks(instructions_per_tx).collect();
 
-    parallel_execute_transactions(client, transactions, signer, retry_count, confirmation_time)
-        .await
-}
-
-pub async fn parallel_execute_transactions(
-    client: &Arc<RpcClient>,
-    transactions: Vec<&[Instruction]>,
-    signer: &Arc<Keypair>,
-    retry_count: u16,
-    confirmation_time: u64,
-) -> Result<(), TransactionExecutionError> {
-    // Accepts a list of transactions (each represented as &[Instruction])
-    // Executes them in parallel, returns the ones that failed to execute
-    // And repeats up to retry_count number of times until all have executed
-    if transactions.is_empty() {
-        return Ok(());
-    }
-
-    let mut error_messages = HashMap::new();
-
-    let mut confirmed_txs = vec![false; transactions.len()];
-
-    for _ in 0..retry_count {
-        // Before submitting, filter transactions based on confirmed_txs and store indices
-        let (remaining_transactions_indices, remaining_transactions): (Vec<_>, Vec<_>) =
-            transactions.iter().enumerate().fold(
-                (Vec::new(), Vec::new()),
-                |(mut idx_vec, mut tx_vec), (i, tx)| {
-                    if !confirmed_txs[i] {
-                        idx_vec.push(i); // Accumulate index and transaction
-                        tx_vec.push(*tx); // Accumulate transaction only
-                    }
-                    (idx_vec, tx_vec) // Return the accumulated vectors for the next iteration
-                },
-            );
-        let (executed_signatures, current_error_messages) =
-            parallel_submit_transactions(client, signer, &remaining_transactions).await?;
-
-        error_messages.extend(
-            current_error_messages
-                .iter()
-                .map(|(i, message)| (remaining_transactions_indices[*i], message.clone())),
-        );
-
-        tokio::time::sleep(Duration::from_secs(confirmation_time)).await;
-
-        let unconfirmed_signatures =
-            parallel_confirm_transactions(client, executed_signatures.clone()).await;
-
-        let confirmed_signatures = executed_signatures
-            .keys()
-            .filter(|sig| !unconfirmed_signatures.contains_key(sig));
-
-        for sig in confirmed_signatures {
-            confirmed_txs[remaining_transactions_indices[executed_signatures[sig]]] = true;
-        }
-
-        // All have been executed
-        if confirmed_txs.iter().all(|&confirmed| confirmed) {
-            return Ok(());
-        }
-    }
-
-    let not_confirmed_message = NOT_CONFIRMED_MESSAGE.to_string();
-    let remaining_transactions_and_errors = confirmed_txs
-        .iter()
-        .enumerate()
-        .filter(|(_, &confirmed)| !confirmed)
-        .map(|(i, _)| {
-            let message = error_messages.get(&i).unwrap_or(&not_confirmed_message);
-            let tx = transactions
-                .get(i)
-                .map(|tx| tx.to_vec())
-                .unwrap_or_default();
-            (tx, message.clone())
-        })
-        .collect::<Vec<_>>();
-
-    Err(TransactionExecutionError::TransactionRetryError(
-        remaining_transactions_and_errors,
-    ))
+    parallel_execute_transactions(
+        client,
+        &transactions,
+        signer,
+        retry_count,
+        confirmation_time,
+    )
+    .await
 }
 
 pub async fn build_create_and_update_instructions<
@@ -470,69 +417,41 @@ pub async fn submit_transactions(
     client: &Arc<RpcClient>,
     transactions: Vec<Vec<Instruction>>,
     keypair: &Arc<Keypair>,
-) -> Result<SubmitStats, (TransactionExecutionError, SubmitStats)> {
+) -> Result<SubmitStats, TransactionExecutionError> {
     let mut stats = SubmitStats::default();
     let num_transactions = transactions.len();
-    match parallel_execute_transactions(
-        client,
-        transactions.iter().map(AsRef::as_ref).collect(),
-        keypair,
-        10,
-        30,
-    )
-    .await
-    {
-        Ok(_) => {
-            stats.successes = num_transactions as u64;
+    let tx_slice = transactions
+        .iter()
+        .map(|t| t.as_slice())
+        .collect::<Vec<_>>();
+
+    match parallel_execute_transactions(client, &tx_slice, keypair, 10, 30).await {
+        Ok(results) => {
+            stats.successes = results.iter().filter(|&tx| tx.is_ok()).count() as u64;
+            stats.errors = num_transactions as u64 - stats.successes;
+            stats.results = results;
+            Ok(stats)
         }
-        Err(e) => {
-            let transactions_len = match e.clone() {
-                TransactionExecutionError::TransactionRetryError(transactions_with_errors) => {
-                    transactions_with_errors.len()
-                }
-                TransactionExecutionError::TransactionClientError(_, transactions) => {
-                    transactions.len()
-                }
-                _ => {
-                    error!("Hit unreachable statement in submit_transactions");
-                    unreachable!();
-                }
-            };
-            stats.successes = num_transactions as u64 - transactions_len as u64;
-            stats.errors = transactions_len as u64;
-            return Err((e, stats));
-        }
+        Err(e) => Err(e),
     }
-    Ok(stats)
 }
 
 pub async fn submit_instructions(
     client: &Arc<RpcClient>,
     instructions: Vec<Instruction>,
     keypair: &Arc<Keypair>,
-) -> Result<SubmitStats, (TransactionExecutionError, SubmitStats)> {
+) -> Result<SubmitStats, TransactionExecutionError> {
     let mut stats = SubmitStats::default();
     let num_instructions = instructions.len();
-    match parallel_execute_instructions(client, instructions, keypair, 10, 30).await {
-        Ok(_) => {
-            stats.successes = num_instructions as u64;
+    match parallel_execute_instructions(client, &instructions, keypair, 10, 30).await {
+        Ok(results) => {
+            stats.successes = results.iter().filter(|&tx| tx.is_ok()).count() as u64;
+            stats.errors = num_instructions as u64 - stats.successes;
+            stats.results = results;
+            Ok(stats)
         }
-        Err(e) => {
-            let instructions_len = match e.clone() {
-                TransactionExecutionError::TransactionRetryError(instructions_with_errors) => {
-                    instructions_with_errors.len()
-                }
-                TransactionExecutionError::ClientError(_, instructions) => instructions.len(),
-                TransactionExecutionError::TransactionClientError(_, instructions) => {
-                    instructions.concat().len()
-                }
-            };
-            stats.successes = num_instructions as u64 - instructions_len as u64;
-            stats.errors = instructions_len as u64;
-            return Err((e, stats));
-        }
+        Err(e) => Err(e),
     }
-    Ok(stats)
 }
 
 pub async fn submit_create_and_update(
@@ -540,19 +459,9 @@ pub async fn submit_create_and_update(
     create_transactions: Vec<Vec<Instruction>>,
     update_instructions: Vec<Instruction>,
     keypair: &Arc<Keypair>,
-) -> Result<CreateUpdateStats, (TransactionExecutionError, CreateUpdateStats)> {
+) -> Result<CreateUpdateStats, TransactionExecutionError> {
     let mut stats = CreateUpdateStats::default();
-    stats.creates = submit_transactions(client, create_transactions, keypair)
-        .await
-        .map_err(|(e, submit_stats)| {
-            stats.creates = submit_stats;
-            (e, stats)
-        })?;
-    stats.updates = submit_instructions(client, update_instructions, keypair)
-        .await
-        .map_err(|(e, submit_stats)| {
-            stats.updates = submit_stats;
-            (e, stats)
-        })?;
+    stats.creates = submit_transactions(client, create_transactions, keypair).await?;
+    stats.updates = submit_instructions(client, update_instructions, keypair).await?;
     Ok(stats)
 }

--- a/keepers/validator-keeper/src/cluster_info.rs
+++ b/keepers/validator-keeper/src/cluster_info.rs
@@ -10,7 +10,7 @@ pub async fn update_cluster_info(
     client: Arc<RpcClient>,
     keypair: Arc<Keypair>,
     program_id: &Pubkey,
-) -> Result<SubmitStats, (TransactionExecutionError, SubmitStats)> {
+) -> Result<SubmitStats, TransactionExecutionError> {
     let (cluster_history_account, _) =
         Pubkey::find_program_address(&[ClusterHistory::SEED], program_id);
 

--- a/keepers/validator-keeper/src/gossip.rs
+++ b/keepers/validator-keeper/src/gossip.rs
@@ -250,7 +250,7 @@ pub async fn upload_gossip_values(
     keypair: Arc<Keypair>,
     entrypoint: SocketAddr,
     program_id: &Pubkey,
-) -> Result<CreateUpdateStats, (Box<dyn std::error::Error>, CreateUpdateStats)> {
+) -> Result<CreateUpdateStats, Box<dyn std::error::Error>> {
     let gossip_port = 0;
 
     let spy_socket_addr = SocketAddr::new(
@@ -261,19 +261,13 @@ pub async fn upload_gossip_values(
     let (_gossip_service, cluster_info) =
         start_spy_server(entrypoint, gossip_port, spy_socket_addr, &keypair, &exit);
 
-    let vote_accounts = get_vote_accounts_with_retry(&client, MIN_VOTE_EPOCHS, None)
-        .await
-        .map_err(|e| (e.into(), CreateUpdateStats::default()))?;
+    let vote_accounts = get_vote_accounts_with_retry(&client, MIN_VOTE_EPOCHS, None).await?;
 
     // Wait for all active validators to be received
     sleep(Duration::from_secs(30)).await;
 
     let gossip_entries = {
-        let crds = cluster_info
-            .gossip
-            .crds
-            .read()
-            .map_err(|e| (e.to_string().into(), CreateUpdateStats::default()))?;
+        let crds = cluster_info.gossip.crds.read().map_err(|e| e.to_string())?;
 
         vote_accounts
             .iter()
@@ -290,9 +284,7 @@ pub async fn upload_gossip_values(
         .iter()
         .map(|a| a.address())
         .collect::<Vec<Pubkey>>();
-    let existing_accounts_response = get_multiple_accounts_batched(&addresses, &client)
-        .await
-        .map_err(|e| (e.into(), CreateUpdateStats::default()))?;
+    let existing_accounts_response = get_multiple_accounts_batched(&addresses, &client).await?;
 
     let create_transactions = existing_accounts_response
         .iter()
@@ -312,19 +304,8 @@ pub async fn upload_gossip_values(
         .collect::<Vec<_>>();
 
     let mut stats = CreateUpdateStats::default();
-    stats.creates = submit_transactions(&client, create_transactions, &keypair)
-        .await
-        .map_err(|(e, submit_stats)| {
-            stats.creates = submit_stats;
-            (e.into(), stats)
-        })?;
-
-    stats.updates = submit_transactions(&client, update_transactions, &keypair)
-        .await
-        .map_err(|(e, submit_stats)| {
-            stats.updates = submit_stats;
-            (e.into(), stats)
-        })?;
+    stats.creates = submit_transactions(&client, create_transactions, &keypair).await?;
+    stats.updates = submit_transactions(&client, update_transactions, &keypair).await?;
 
     Ok(stats)
 }

--- a/keepers/validator-keeper/src/gossip.rs
+++ b/keepers/validator-keeper/src/gossip.rs
@@ -303,11 +303,10 @@ pub async fn upload_gossip_values(
         .map(|entry| entry.build_update_tx())
         .collect::<Vec<_>>();
 
-    let mut stats = CreateUpdateStats::default();
-    stats.creates = submit_transactions(&client, create_transactions, &keypair).await?;
-    stats.updates = submit_transactions(&client, update_transactions, &keypair).await?;
-
-    Ok(stats)
+    Ok(CreateUpdateStats {
+        creates: submit_transactions(&client, create_transactions, &keypair).await?,
+        updates: submit_transactions(&client, update_transactions, &keypair).await?,
+    })
 }
 
 // CODE BELOW SLIGHTLY MODIFIED FROM

--- a/keepers/validator-keeper/src/lib.rs
+++ b/keepers/validator-keeper/src/lib.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use anchor_lang::{AccountDeserialize, Discriminator};
-use keeper_core::{CreateUpdateStats, SubmitStats};
+use keeper_core::{get_vote_accounts_with_retry, CreateUpdateStats, SubmitStats};
 use log::error;
 use solana_account_decoder::UiDataSliceConfig;
 use solana_client::{
@@ -25,7 +25,9 @@ use solana_sdk::{
 use solana_streamer::socket::SocketAddrSpace;
 
 use jito_tip_distribution::state::TipDistributionAccount;
-use validator_history::{ClusterHistory, ValidatorHistory, ValidatorHistoryEntry};
+use validator_history::{
+    constants::MIN_VOTE_EPOCHS, ClusterHistory, ValidatorHistory, ValidatorHistoryEntry,
+};
 
 pub mod cluster_info;
 pub mod gossip;
@@ -195,6 +197,10 @@ pub async fn emit_validator_history_metrics(
         }
     }
 
+    let get_vote_accounts_count = get_vote_accounts_with_retry(client, MIN_VOTE_EPOCHS, None)
+        .await?
+        .len();
+
     datapoint_info!(
         "validator-history-stats",
         ("num_validator_histories", num_validators, i64),
@@ -207,6 +213,11 @@ pub async fn emit_validator_history_metrics(
         ("num_stakes", stakes, i64),
         ("cluster_history_blocks", cluster_history_blocks, i64),
         ("slot_index", epoch.slot_index, i64),
+        (
+            "num_get_vote_accounts_responses",
+            get_vote_accounts_count,
+            i64
+        ),
     );
 
     Ok(())

--- a/keepers/validator-keeper/src/lib.rs
+++ b/keepers/validator-keeper/src/lib.rs
@@ -237,9 +237,8 @@ pub async fn get_validator_history_accounts_with_retry(
     program_id: Pubkey,
 ) -> Result<Vec<ValidatorHistory>, ClientError> {
     for _ in 0..4 {
-        match get_validator_history_accounts(client, program_id).await {
-            Ok(validator_histories) => return Ok(validator_histories),
-            Err(_) => {}
+        if let Ok(validator_histories) = get_validator_history_accounts(client, program_id).await {
+            return Ok(validator_histories);
         }
     }
     get_validator_history_accounts(client, program_id).await

--- a/keepers/validator-keeper/src/main.rs
+++ b/keepers/validator-keeper/src/main.rs
@@ -174,7 +174,7 @@ async fn vote_account_loop(
             runs_for_epoch = 0;
         }
         // Run at 10%, 50% and 90% completion of epoch
-        let should_run = (epoch_info.slot_index > epoch_info.slots_in_epoch / 10
+        let should_run = (epoch_info.slot_index > epoch_info.slots_in_epoch / 1000
             && runs_for_epoch < 1)
             || (epoch_info.slot_index > epoch_info.slots_in_epoch / 2 && runs_for_epoch < 2)
             || (epoch_info.slot_index > epoch_info.slots_in_epoch * 9 / 10 && runs_for_epoch < 3);

--- a/keepers/validator-keeper/src/mev_commission.rs
+++ b/keepers/validator-keeper/src/mev_commission.rs
@@ -187,12 +187,8 @@ pub async fn update_mev_earned(
     tip_distribution_program_id: &Pubkey,
     validators_updated: &mut HashMap<Pubkey, Pubkey>,
     curr_epoch: &mut u64,
-) -> Result<CreateUpdateStats, (MevCommissionError, CreateUpdateStats)> {
-    let epoch = client
-        .get_epoch_info()
-        .await
-        .map_err(|e| (e.into(), CreateUpdateStats::default()))?
-        .epoch;
+) -> Result<CreateUpdateStats, KeeperError> {
+    let epoch = client.get_epoch_info().await?.epoch;
 
     if epoch > *curr_epoch {
         // new epoch started, we assume here that all the validators with TDAs from curr_epoch-1 have had their merkle roots uploaded/processed by this point
@@ -201,9 +197,7 @@ pub async fn update_mev_earned(
     }
     *curr_epoch = epoch;
 
-    let vote_accounts = get_vote_accounts_with_retry(client, MIN_VOTE_EPOCHS, None)
-        .await
-        .map_err(|e| (e.into(), CreateUpdateStats::default()))?;
+    let vote_accounts = get_vote_accounts_with_retry(client, MIN_VOTE_EPOCHS, None).await?;
 
     let entries = vote_accounts
         .iter()
@@ -218,18 +212,15 @@ pub async fn update_mev_earned(
         })
         .collect::<Vec<ValidatorMevCommissionEntry>>();
 
-    let uploaded_merkleroot_entries = get_entries_with_uploaded_merkleroot(client, &entries)
-        .await
-        .map_err(|e| (e.into(), CreateUpdateStats::default()))?;
+    let uploaded_merkleroot_entries =
+        get_entries_with_uploaded_merkleroot(client, &entries).await?;
 
     let entries_to_update = uploaded_merkleroot_entries
         .into_iter()
         .filter(|entry| !validators_updated.contains_key(&entry.tip_distribution_account))
         .collect::<Vec<ValidatorMevCommissionEntry>>();
     let (create_transactions, update_instructions) =
-        build_create_and_update_instructions(client, &entries_to_update)
-            .await
-            .map_err(|e| (e.into(), CreateUpdateStats::default()))?;
+        build_create_and_update_instructions(client, &entries_to_update).await?;
 
     let submit_result =
         submit_create_and_update(client, create_transactions, update_instructions, keypair).await;
@@ -243,7 +234,7 @@ pub async fn update_mev_earned(
             validators_updated.insert(tip_distribution_account, vote_account);
         }
     }
-    submit_result.map_err(|(e, stats)| (e.into(), stats))
+    submit_result.map_err(|e| e.into())
 }
 
 async fn get_existing_entries(

--- a/keepers/validator-keeper/src/mev_commission.rs
+++ b/keepers/validator-keeper/src/mev_commission.rs
@@ -160,22 +160,24 @@ pub async fn update_mev_commission(
     let (create_transactions, update_instructions) =
         build_create_and_update_instructions(&client, &entries_to_update).await?;
 
-    let submit_result =
-        submit_create_and_update(&client, create_transactions, update_instructions, &keypair).await;
-
-    // TODO this is wrong
-
-    if submit_result.is_ok() {
-        for ValidatorMevCommissionEntry {
-            vote_account,
-            tip_distribution_account,
-            ..
-        } in entries_to_update
-        {
-            validators_updated.insert(tip_distribution_account, vote_account);
+    match submit_create_and_update(&client, create_transactions, update_instructions, &keypair)
+        .await
+    {
+        Ok(submit_result) => {
+            if submit_result.creates.errors == 0 && submit_result.updates.errors == 0 {
+                for ValidatorMevCommissionEntry {
+                    vote_account,
+                    tip_distribution_account,
+                    ..
+                } in entries_to_update
+                {
+                    validators_updated.insert(tip_distribution_account, vote_account);
+                }
+            }
+            Ok(submit_result)
         }
+        Err(e) => Err(e.into()),
     }
-    submit_result.map_err(|e| e.into())
 }
 
 pub async fn update_mev_earned(

--- a/keepers/validator-keeper/src/stake.rs
+++ b/keepers/validator-keeper/src/stake.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
 use keeper_core::{
     build_create_and_update_instructions, get_vote_accounts_with_retry, submit_create_and_update,
-    submit_instructions, Address, CreateTransaction, CreateUpdateStats, SubmitStats,
+    submit_instructions, Address, CreateTransaction, CreateUpdateStats,
     UpdateInstruction,
 };
 use log::error;

--- a/keepers/validator-keeper/src/stake.rs
+++ b/keepers/validator-keeper/src/stake.rs
@@ -3,8 +3,7 @@ use std::{collections::HashMap, str::FromStr, sync::Arc};
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
 use keeper_core::{
     build_create_and_update_instructions, get_vote_accounts_with_retry, submit_create_and_update,
-    submit_instructions, Address, CreateTransaction, CreateUpdateStats,
-    UpdateInstruction,
+    submit_instructions, Address, CreateTransaction, CreateUpdateStats, UpdateInstruction,
 };
 use log::error;
 use solana_client::{

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -9,7 +9,6 @@ use keeper_core::{
     TransactionExecutionError, UpdateInstruction,
 };
 use log::error;
-use solana_client::rpc_response::RpcVoteAccountInfo;
 use solana_client::{client_error::ClientError, nonblocking::rpc_client::RpcClient};
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use solana_sdk::{signature::Keypair, signer::Signer};

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -17,7 +17,7 @@ use validator_history::constants::{MAX_ALLOC_BYTES, MIN_VOTE_EPOCHS};
 use validator_history::state::ValidatorHistory;
 use validator_history::Config;
 
-use crate::get_validator_history_accounts_with_retry;
+use crate::{get_validator_history_accounts_with_retry, KeeperError};
 
 #[derive(ThisError, Debug)]
 pub enum UpdateCommissionError {
@@ -112,7 +112,7 @@ pub async fn update_vote_accounts(
     rpc_client: Arc<RpcClient>,
     keypair: Arc<Keypair>,
     validator_history_program_id: Pubkey,
-) -> Result<CreateUpdateStats, (UpdateCommissionError, CreateUpdateStats)> {
+) -> Result<CreateUpdateStats, (KeeperError, CreateUpdateStats)> {
     let stats = CreateUpdateStats::default();
 
     let rpc_vote_accounts = get_vote_accounts_with_retry(&rpc_client, MIN_VOTE_EPOCHS, None)

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -8,7 +8,7 @@ use keeper_core::{
     Address, CreateTransaction, CreateUpdateStats, UpdateInstruction,
 };
 use log::error;
-use solana_client::{nonblocking::rpc_client::RpcClient};
+use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use solana_sdk::{signature::Keypair, signer::Signer};
 

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -5,14 +5,13 @@ use std::sync::Arc;
 use anchor_lang::{InstructionData, ToAccountMetas};
 use keeper_core::{
     build_create_and_update_instructions, get_vote_accounts_with_retry, submit_create_and_update,
-    Address, CreateTransaction, CreateUpdateStats, MultipleAccountsError,
-    TransactionExecutionError, UpdateInstruction,
+    Address, CreateTransaction, CreateUpdateStats, UpdateInstruction,
 };
 use log::error;
-use solana_client::{client_error::ClientError, nonblocking::rpc_client::RpcClient};
+use solana_client::{nonblocking::rpc_client::RpcClient};
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use solana_sdk::{signature::Keypair, signer::Signer};
-use thiserror::Error as ThisError;
+
 use validator_history::constants::{MAX_ALLOC_BYTES, MIN_VOTE_EPOCHS};
 use validator_history::state::ValidatorHistory;
 use validator_history::Config;


### PR DESCRIPTION
Improves keeper reliability for landing transactions by:
* no longer skipping transactions that initially fail with a BlockhashNotFound error
* Merging vote accounts with all validator history accounts for epoch credit cranking, so offline validators that no longer showing up in getVoteAccounts still get cranked (necessary for Steward program scoring)

The first part has already been running on mainnet for a week, and for the last 3 epochs, all vote accounts have been updated each epoch (as measured by: same number of commissions tracked as stakes). 