### PR TITLE
Fixes + cleanup for updated keeper

### DIFF
--- a/keepers/validator-keeper/src/gossip.rs
+++ b/keepers/validator-keeper/src/gossip.rs
@@ -19,6 +19,7 @@ use solana_client::{nonblocking::rpc_client::RpcClient, rpc_response::RpcVoteAcc
 use solana_gossip::{
     crds::Crds,
     crds_value::{CrdsData, CrdsValue, CrdsValueLabel},
+    legacy_contact_info,
 };
 use solana_metrics::datapoint_info;
 use solana_sdk::{
@@ -34,7 +35,7 @@ use validator_history::{
     Config, ValidatorHistory,
 };
 
-use crate::start_spy_server;
+use crate::{get_validator_history_accounts_with_retry, start_spy_server};
 
 #[derive(Clone, Debug)]
 pub struct GossipEntry {
@@ -148,12 +149,38 @@ pub fn emit_gossip_datapoint(stats: CreateUpdateStats, runs_for_epoch: i64) {
     );
 }
 
-fn check_entry_valid(entry: &CrdsValue, validator_identity: Pubkey) -> bool {
+fn check_entry_valid(
+    entry: &CrdsValue,
+    validator_history: &ValidatorHistory,
+    validator_identity: Pubkey,
+) -> bool {
+    // Filters out invalid gossip entries that would fail transaction submission. Checks for:
+    // 0. Entry belongs to one of the expected types
+    // 1. Entry timestamp is not too old
+    // 2. Entry is for the correct validator
     match &entry.data {
-        CrdsData::LegacyContactInfo(_) => {}
-        CrdsData::LegacyVersion(_) => {}
-        CrdsData::Version(_) => {}
-        CrdsData::ContactInfo(_) => {}
+        CrdsData::LegacyContactInfo(legacy_contact_info) => {
+            if legacy_contact_info.wallclock() < validator_history.last_ip_timestamp {
+                return false;
+            }
+        }
+        CrdsData::LegacyVersion(legacy_version) => {
+            if legacy_version.wallclock < validator_history.last_version_timestamp {
+                return false;
+            }
+        }
+        CrdsData::Version(version) => {
+            if version.wallclock < validator_history.last_version_timestamp {
+                return false;
+            }
+        }
+        CrdsData::ContactInfo(contact_info) => {
+            if contact_info.wallclock() < validator_history.last_ip_timestamp
+                || contact_info.wallclock() < validator_history.last_version_timestamp
+            {
+                return false;
+            }
+        }
         _ => {
             return false;
         }
@@ -173,6 +200,7 @@ fn check_entry_valid(entry: &CrdsValue, validator_identity: Pubkey) -> bool {
 
 fn build_gossip_entry(
     vote_account: &RpcVoteAccountInfo,
+    validator_history: &ValidatorHistory,
     crds: &RwLockReadGuard<'_, Crds>,
     program_id: Pubkey,
     keypair: &Arc<Keypair>,
@@ -189,7 +217,7 @@ fn build_gossip_entry(
     // Current ContactInfo has both IP and Version, but LegacyContactInfo has only IP.
     // So if there is not ContactInfo, we need to submit tx for LegacyContactInfo + one of (Version, LegacyVersion)
     if let Some(entry) = crds.get::<&CrdsValue>(&contact_info_key) {
-        if !check_entry_valid(entry, validator_identity) {
+        if !check_entry_valid(entry, validator_history, validator_identity) {
             return None;
         }
         Some(vec![GossipEntry::new(
@@ -203,7 +231,7 @@ fn build_gossip_entry(
     } else {
         let mut entries = vec![];
         if let Some(entry) = crds.get::<&CrdsValue>(&legacy_contact_info_key) {
-            if !check_entry_valid(entry, validator_identity) {
+            if !check_entry_valid(entry, validator_history, validator_identity) {
                 return None;
             }
             entries.push(GossipEntry::new(
@@ -217,7 +245,7 @@ fn build_gossip_entry(
         }
 
         if let Some(entry) = crds.get::<&CrdsValue>(&version_key) {
-            if !check_entry_valid(entry, validator_identity) {
+            if !check_entry_valid(entry, validator_history, validator_identity) {
                 return None;
             }
             entries.push(GossipEntry::new(
@@ -229,7 +257,7 @@ fn build_gossip_entry(
                 &keypair.pubkey(),
             ))
         } else if let Some(entry) = crds.get::<&CrdsValue>(&legacy_version_key) {
-            if !check_entry_valid(entry, validator_identity) {
+            if !check_entry_valid(entry, validator_history, validator_identity) {
                 return None;
             }
             entries.push(GossipEntry::new(
@@ -262,6 +290,8 @@ pub async fn upload_gossip_values(
         start_spy_server(entrypoint, gossip_port, spy_socket_addr, &keypair, &exit);
 
     let vote_accounts = get_vote_accounts_with_retry(&client, MIN_VOTE_EPOCHS, None).await?;
+    let validator_history_accounts =
+        get_validator_history_accounts_with_retry(&client, *program_id).await?;
 
     // Wait for all active validators to be received
     sleep(Duration::from_secs(30)).await;
@@ -272,7 +302,18 @@ pub async fn upload_gossip_values(
         vote_accounts
             .iter()
             .filter_map(|vote_account| {
-                build_gossip_entry(vote_account, &crds, *program_id, &keypair)
+                let vote_account_pubkey = Pubkey::from_str(&vote_account.vote_pubkey).ok()?;
+                let validator_history_account = validator_history_accounts
+                    .iter()
+                    .find(|account| account.vote_account == vote_account_pubkey)?;
+
+                build_gossip_entry(
+                    vote_account,
+                    validator_history_account,
+                    &crds,
+                    *program_id,
+                    &keypair,
+                )
             })
             .flatten()
             .collect::<Vec<_>>()

--- a/keepers/validator-keeper/src/gossip.rs
+++ b/keepers/validator-keeper/src/gossip.rs
@@ -19,7 +19,6 @@ use solana_client::{nonblocking::rpc_client::RpcClient, rpc_response::RpcVoteAcc
 use solana_gossip::{
     crds::Crds,
     crds_value::{CrdsData, CrdsValue, CrdsValueLabel},
-    legacy_contact_info,
 };
 use solana_metrics::datapoint_info;
 use solana_sdk::{

--- a/keepers/validator-keeper/src/main.rs
+++ b/keepers/validator-keeper/src/main.rs
@@ -411,6 +411,7 @@ async fn gossip_upload_loop(
     }
 }
 
+#[allow(dead_code)]
 async fn cluster_history_loop(
     client: Arc<RpcClient>,
     keypair: Arc<Keypair>,

--- a/keepers/validator-keeper/src/main.rs
+++ b/keepers/validator-keeper/src/main.rs
@@ -103,7 +103,19 @@ async fn mev_commission_loop(
         )
         .await
         {
-            Ok(stats) => stats,
+            Ok(stats) => {
+                for message in stats
+                    .creates
+                    .results
+                    .iter()
+                    .chain(stats.updates.results.iter())
+                {
+                    if let Err(e) = message {
+                        datapoint_error!("vote-account-error", ("error", e.to_string(), String),);
+                    }
+                }
+                stats
+            }
             Err(e) => {
                 let mut stats = CreateUpdateStats::default();
                 if let KeeperError::TransactionExecutionError(
@@ -146,7 +158,19 @@ async fn mev_earned_loop(
         )
         .await
         {
-            Ok(stats) => stats,
+            Ok(stats) => {
+                for message in stats
+                    .creates
+                    .results
+                    .iter()
+                    .chain(stats.updates.results.iter())
+                {
+                    if let Err(e) = message {
+                        datapoint_error!("vote-account-error", ("error", e.to_string(), String),);
+                    }
+                }
+                stats
+            }
             Err(e) => {
                 let mut stats = CreateUpdateStats::default();
                 if let KeeperError::TransactionExecutionError(
@@ -421,6 +445,14 @@ async fn cluster_history_loop(
         if should_run {
             stats = match update_cluster_info(client.clone(), keypair.clone(), &program_id).await {
                 Ok(run_stats) => {
+                    for message in run_stats.results.iter() {
+                        if let Err(e) = message {
+                            datapoint_error!(
+                                "cluster-history-error",
+                                ("error", e.to_string(), String),
+                            );
+                        }
+                    }
                     if run_stats.errors == 0 {
                         runs_for_epoch += 1;
                     }
@@ -466,12 +498,13 @@ async fn main() {
         args.interval,
     ));
 
-    tokio::spawn(cluster_history_loop(
-        Arc::clone(&client),
-        Arc::clone(&keypair),
-        args.program_id,
-        args.interval,
-    ));
+    // TODO fix cluster history instruction
+    // tokio::spawn(cluster_history_loop(
+    //     Arc::clone(&client),
+    //     Arc::clone(&keypair),
+    //     args.program_id,
+    //     args.interval,
+    // ));
 
     tokio::spawn(vote_account_loop(
         Arc::clone(&client),

--- a/keepers/validator-keeper/src/main.rs
+++ b/keepers/validator-keeper/src/main.rs
@@ -411,7 +411,6 @@ async fn gossip_upload_loop(
     }
 }
 
-#[allow(dead_code)]
 async fn cluster_history_loop(
     client: Arc<RpcClient>,
     keypair: Arc<Keypair>,
@@ -499,13 +498,12 @@ async fn main() {
         args.interval,
     ));
 
-    // TODO fix cluster history instruction
-    // tokio::spawn(cluster_history_loop(
-    //     Arc::clone(&client),
-    //     Arc::clone(&keypair),
-    //     args.program_id,
-    //     args.interval,
-    // ));
+    tokio::spawn(cluster_history_loop(
+        Arc::clone(&client),
+        Arc::clone(&keypair),
+        args.program_id,
+        args.interval,
+    ));
 
     tokio::spawn(vote_account_loop(
         Arc::clone(&client),

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -2,13 +2,15 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anchor_lang::{InstructionData, ToAccountMetas};
+use anchor_lang::{system_program, InstructionData, ToAccountMetas};
 use keeper_core::{
-    build_create_and_update_instructions, get_vote_accounts_with_retry, submit_create_and_update,
+    build_create_and_update_instructions, get_multiple_accounts_batched,
+    get_multiple_accounts_with_retry, get_vote_accounts_with_retry, submit_create_and_update,
     Address, CreateTransaction, CreateUpdateStats, UpdateInstruction,
 };
 use log::error;
 use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_program::vote;
 use solana_program::{instruction::Instruction, pubkey::Pubkey};
 use solana_sdk::{signature::Keypair, signer::Signer};
 
@@ -109,8 +111,29 @@ pub async fn update_vote_accounts(
         get_validator_history_accounts_with_retry(&rpc_client, validator_history_program_id)
             .await?;
 
+    let vote_account_pubkeys = validator_histories
+        .iter()
+        .map(|vh| vh.vote_account)
+        .collect::<Vec<_>>();
+
+    let vote_accounts = get_multiple_accounts_batched(&vote_account_pubkeys, &rpc_client).await?;
+    let closed_vote_accounts: HashSet<Pubkey> = vote_accounts
+        .iter()
+        .enumerate()
+        .filter_map(|(i, account)| match account {
+            Some(account) => {
+                if account.owner != vote::program::id() {
+                    Some(vote_account_pubkeys[i])
+                } else {
+                    None
+                }
+            }
+            None => Some(vote_account_pubkeys[i]),
+        })
+        .collect();
+
     // Merges new and active RPC vote accounts with all validator history accounts, and dedupes
-    let vote_accounts = rpc_vote_accounts
+    let mut all_vote_accounts = rpc_vote_accounts
         .iter()
         .filter_map(|rpc_va| {
             Pubkey::from_str(&rpc_va.vote_pubkey)
@@ -123,7 +146,10 @@ pub async fn update_vote_accounts(
         .chain(validator_histories.iter().map(|vh| vh.vote_account))
         .collect::<HashSet<_>>();
 
-    let entries = vote_accounts
+    // Remove closed vote accounts from all vote accounts
+    all_vote_accounts.retain(|va| !closed_vote_accounts.contains(va));
+
+    let entries = all_vote_accounts
         .iter()
         .map(|va| CopyVoteAccountEntry::new(va, &validator_history_program_id, &keypair.pubkey()))
         .collect::<Vec<_>>();

--- a/keepers/validator-keeper/src/vote_account.rs
+++ b/keepers/validator-keeper/src/vote_account.rs
@@ -2,11 +2,11 @@ use std::collections::HashSet;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use anchor_lang::{system_program, InstructionData, ToAccountMetas};
+use anchor_lang::{InstructionData, ToAccountMetas};
 use keeper_core::{
     build_create_and_update_instructions, get_multiple_accounts_batched,
-    get_multiple_accounts_with_retry, get_vote_accounts_with_retry, submit_create_and_update,
-    Address, CreateTransaction, CreateUpdateStats, UpdateInstruction,
+    get_vote_accounts_with_retry, submit_create_and_update, Address, CreateTransaction,
+    CreateUpdateStats, UpdateInstruction,
 };
 use log::error;
 use solana_client::nonblocking::rpc_client::RpcClient;

--- a/programs/validator-history/src/utils.rs
+++ b/programs/validator-history/src/utils.rs
@@ -28,9 +28,9 @@ mod tests {
 
     #[test]
     fn test_fixed_point_sol() {
-        assert_eq!(fixed_point_sol(1000000000), 100);
-        assert_eq!(fixed_point_sol(4294967295000000000), 4294967295);
+        assert_eq!(fixed_point_sol(1_000_000_000), 100);
+        assert_eq!(fixed_point_sol(4_294_967_295_000_000_000), 4294967295);
 
-        assert_eq!(fixed_point_sol(429496729600000000), 4294967295)
+        assert_eq!(fixed_point_sol(429_496_729_600_000_000), 4294967295)
     }
 }

--- a/utils/validator-history-cli/src/main.rs
+++ b/utils/validator-history-cli/src/main.rs
@@ -1,18 +1,20 @@
-use std::{path::PathBuf, time::Duration};
+use std::{path::PathBuf, thread::sleep, time::Duration};
 
 use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountMetas};
 use clap::{arg, command, Parser, Subcommand};
 use solana_client::{
     rpc_client::RpcClient,
-    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
+    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig},
     rpc_filter::{Memcmp, RpcFilterType},
 };
-use solana_program::instruction::Instruction;
+use solana_program::{instruction::Instruction, native_token::lamports_to_sol};
 use solana_sdk::{
-    pubkey::Pubkey, signature::read_keypair_file, signer::Signer, transaction::Transaction,
+    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction, pubkey::Pubkey,
+    signature::read_keypair_file, signer::Signer, transaction::Transaction,
 };
 use validator_history::{
-    constants::MAX_ALLOC_BYTES, ClusterHistory, Config, ValidatorHistory, ValidatorHistoryEntry,
+    constants::MAX_ALLOC_BYTES, ClusterHistory, ClusterHistoryEntry, Config, ValidatorHistory,
+    ValidatorHistoryEntry,
 };
 
 #[derive(Parser)]
@@ -36,6 +38,7 @@ enum Commands {
     InitConfig(InitConfig),
     InitClusterHistory(InitClusterHistory),
     CrankerStatus(CrankerStatus),
+    ClusterHistoryStatus,
     History(History),
     BackfillClusterHistory(BackfillClusterHistory),
 }
@@ -259,6 +262,12 @@ fn formatted_entry(entry: ValidatorHistoryEntry) -> String {
             entry.mev_commission.to_string()
         };
 
+    let mev_earned_str = if entry.mev_earned == ValidatorHistoryEntry::default().mev_earned {
+        "[NULL]".to_string()
+    } else {
+        (entry.mev_earned as f64 / 100.0).to_string()
+    };
+
     let stake_str = if entry.activated_stake_lamports
         == ValidatorHistoryEntry::default().activated_stake_lamports
     {
@@ -317,10 +326,11 @@ fn formatted_entry(entry: ValidatorHistoryEntry) -> String {
     };
 
     format!(
-        "Commission: {}\t| Epoch Credits: {}\t| MEV Commission: {}\t| Stake: {}\t| Rank: {}\t| Superminority: {}\t| IP: {}\t| Client Type: {}\t| Client Version: {}\t| Last Updated: {}",
+        "Commission: {}\t| Epoch Credits: {}\t| MEV Commission: {}\t| MEV Earned: {}\t| Stake: {}\t| Rank: {}\t| Superminority: {}\t| IP: {}\t| Client Type: {}\t| Client Version: {}\t| Last Updated: {}",
         commission_str,
         epoch_credits_str,
         mev_commission_str,
+        mev_earned_str,
         stake_str,
         rank_str,
         superminority_str,
@@ -388,11 +398,14 @@ fn command_cranker_status(args: CrankerStatus, client: RpcClient) {
     let mut versions = 0;
     let mut types = 0;
     let mut mev_comms = 0;
+    let mut mev_earned = 0;
     let mut comms = 0;
     let mut epoch_credits = 0;
     let mut stakes = 0;
     let mut ranks = 0;
     let mut superminorities = 0;
+
+    let mut missed_mev_earned = 0;
     let default = ValidatorHistoryEntry::default();
     for validator_history in validator_histories {
         match get_entry(validator_history, epoch) {
@@ -411,6 +424,14 @@ fn command_cranker_status(args: CrankerStatus, client: RpcClient) {
                 }
                 if entry.mev_commission != default.mev_commission {
                     mev_comms += 1;
+                }
+                if entry.mev_earned != default.mev_earned {
+                    mev_earned += 1;
+                }
+                if entry.mev_earned == default.mev_earned
+                    && entry.mev_commission != default.mev_commission
+                {
+                    missed_mev_earned += 1;
                 }
                 if entry.commission != default.commission {
                     comms += 1;
@@ -449,11 +470,12 @@ fn command_cranker_status(args: CrankerStatus, client: RpcClient) {
     println!("Validators with Version:\t{}", versions);
     println!("Validators with Client Type:\t{}", types);
     println!("Validators with MEV Commission: {}", mev_comms);
+    println!("Validators with MEV Earned: \t{}", mev_earned);
     println!("Validators with Commission:\t{}", comms);
     println!("Validators with Epoch Credits:\t{}", epoch_credits);
     println!("Validators with Stake:\t\t{}", stakes);
     println!("Validators with Rank:\t\t{}", ranks);
-    println!("Validators with Superminority:\t\t{}", superminorities);
+    println!("Missed MEV Earned:\t\t{}", missed_mev_earned);
 }
 
 fn command_history(args: History, client: RpcClient) {
@@ -504,27 +526,77 @@ fn command_history(args: History, client: RpcClient) {
     }
 }
 
+fn command_cluster_history(client: RpcClient) {
+    let (cluster_history_pda, _) =
+        Pubkey::find_program_address(&[ClusterHistory::SEED], &validator_history::ID);
+
+    let cluster_history_account = client
+        .get_account(&cluster_history_pda)
+        .expect("Failed to get cluster history account");
+    let cluster_history =
+        ClusterHistory::try_deserialize(&mut cluster_history_account.data.as_slice())
+            .expect("Failed to deserialize cluster history account");
+
+    // let start_epoch = cluster_history
+    //     .history
+    //     .arr
+    //     .iter()
+    //     .filter_map(|entry| {
+    //         if entry.epoch > 0 {
+    //             Some(entry.epoch as u64)
+    //         } else {
+    //             None
+    //         }
+    //     })
+    //     .min()
+    //     .unwrap_or(0);
+
+    for entry in cluster_history.history.arr.iter() {
+        println!(
+            "Epoch: {} | Total Blocks: {}",
+            entry.epoch, entry.total_blocks
+        );
+
+        if entry.epoch == ClusterHistoryEntry::default().epoch {
+            break;
+        }
+    }
+}
+
 fn command_backfill_cluster_history(args: BackfillClusterHistory, client: RpcClient) {
     // Backfill cluster history account for a specific epoch
     let keypair = read_keypair_file(args.keypair_path).expect("Failed reading keypair file");
+    sleep(Duration::from_secs(5));
 
     let mut instructions = vec![];
     let (cluster_history_pda, _) =
         Pubkey::find_program_address(&[ClusterHistory::SEED], &validator_history::ID);
-    let (config, _) = Pubkey::find_program_address(&[Config::SEED], &validator_history::ID);
+    // let (config, _) = Pubkey::find_program_address(&[Config::SEED], &validator_history::ID);
+    // let cluster_history_account = client
+    //     .get_account(&cluster_history_pda)
+    //     .expect("Failed to get cluster history account");
+    // let cluster_history =
+    //     ClusterHistory::try_deserialize(&mut cluster_history_account.data.as_slice())
+    //         .expect("Failed to deserialize cluster history account");
+
+    // if !cluster_history.history.is_empty()
+    //     && cluster_history.history.last().unwrap().epoch + 1 != args.epoch as u16
+    // {
+    //     panic!("Cannot set this epoch, you would mess up the ordering");
+    // }
+    let max_heap_instruction: Instruction =
+        ComputeBudgetInstruction::request_heap_frame(148 * 1024);
+    instructions.push(max_heap_instruction);
+
     instructions.push(Instruction {
         program_id: validator_history::ID,
-        accounts: validator_history::accounts::BackfillTotalBlocks {
+        accounts: validator_history::accounts::CopyClusterInfo {
             cluster_history_account: cluster_history_pda,
-            config,
+            slot_history: solana_program::sysvar::slot_history::id(),
             signer: keypair.pubkey(),
         }
         .to_account_metas(None),
-        data: validator_history::instruction::BackfillTotalBlocks {
-            epoch: args.epoch,
-            blocks_in_epoch: args.blocks_in_epoch,
-        }
-        .data(),
+        data: validator_history::instruction::CopyClusterInfo {}.data(),
     });
 
     let blockhash = client
@@ -538,7 +610,14 @@ fn command_backfill_cluster_history(args: BackfillClusterHistory, client: RpcCli
     );
 
     let signature = client
-        .send_and_confirm_transaction_with_spinner(&transaction)
+        .send_and_confirm_transaction_with_spinner_and_config(
+            &transaction,
+            CommitmentConfig::processed(),
+            RpcSendTransactionConfig {
+                skip_preflight: true,
+                ..RpcSendTransactionConfig::default()
+            },
+        )
         .expect("Failed to send transaction");
     println!("Signature: {}", signature);
 }
@@ -550,6 +629,7 @@ fn main() {
         Commands::InitConfig(args) => command_init_config(args, client),
         Commands::CrankerStatus(args) => command_cranker_status(args, client),
         Commands::InitClusterHistory(args) => command_init_cluster_history(args, client),
+        Commands::ClusterHistoryStatus => command_cluster_history(client),
         Commands::History(args) => command_history(args, client),
         Commands::BackfillClusterHistory(args) => command_backfill_cluster_history(args, client),
     };

--- a/utils/validator-history-cli/src/main.rs
+++ b/utils/validator-history-cli/src/main.rs
@@ -4,13 +4,12 @@ use anchor_lang::{AccountDeserialize, Discriminator, InstructionData, ToAccountM
 use clap::{arg, command, Parser, Subcommand};
 use solana_client::{
     rpc_client::RpcClient,
-    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig, RpcSendTransactionConfig},
+    rpc_config::{RpcAccountInfoConfig, RpcProgramAccountsConfig},
     rpc_filter::{Memcmp, RpcFilterType},
 };
-use solana_program::{instruction::Instruction, native_token::lamports_to_sol};
+use solana_program::instruction::Instruction;
 use solana_sdk::{
-    commitment_config::CommitmentConfig, compute_budget::ComputeBudgetInstruction, pubkey::Pubkey,
-    signature::read_keypair_file, signer::Signer, transaction::Transaction,
+    pubkey::Pubkey, signature::read_keypair_file, signer::Signer, transaction::Transaction,
 };
 use validator_history::{
     constants::MAX_ALLOC_BYTES, ClusterHistory, ClusterHistoryEntry, Config, ValidatorHistory,
@@ -403,7 +402,6 @@ fn command_cranker_status(args: CrankerStatus, client: RpcClient) {
     let mut epoch_credits = 0;
     let mut stakes = 0;
     let mut ranks = 0;
-    let mut superminorities = 0;
 
     let default = ValidatorHistoryEntry::default();
     for validator_history in validator_histories {
@@ -438,9 +436,6 @@ fn command_cranker_status(args: CrankerStatus, client: RpcClient) {
                 }
                 if entry.rank != default.rank {
                     ranks += 1;
-                }
-                if entry.is_superminority != default.is_superminority {
-                    superminorities += 1;
                 }
                 println!(
                     "{}.\tVote Account: {} | {}",


### PR DESCRIPTION
New keeper will retry failed transactions forever, so we need to prevent sending txs that are doomed from the start. Also some nit improvements.

* ~Comments out cluster history cranking until that is fixed~
* Filtering out closed vote accounts for now
* Filtering out gossip values that are expired
