### PR TITLE
Math fixes for cluster history slot counting

### DIFF
--- a/keepers/validator-keeper/src/cluster_info.rs
+++ b/keepers/validator-keeper/src/cluster_info.rs
@@ -18,7 +18,7 @@ pub async fn update_cluster_info(
 
     let heap_request_ix = compute_budget::ComputeBudgetInstruction::request_heap_frame(256 * 1024);
     let compute_budget_ix =
-        compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_000_000);
+        compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
     let update_instruction = Instruction {
         program_id: *program_id,
         accounts: validator_history::accounts::CopyClusterInfo {

--- a/tests/src/fixtures.rs
+++ b/tests/src/fixtures.rs
@@ -264,6 +264,7 @@ impl TestFixture {
 
         clock.epoch_start_timestamp += (dif_slots * ms_per_slot) as i64;
         clock.unix_timestamp += (dif_slots * ms_per_slot) as i64;
+        clock.slot += dif_slots;
         self.ctx.borrow_mut().set_sysvar(&clock);
 
         dif_slots

--- a/tests/tests/test_cluster_history.rs
+++ b/tests/tests/test_cluster_history.rs
@@ -4,6 +4,7 @@ use {
         solana_program::{instruction::Instruction, slot_history::SlotHistory},
         InstructionData, ToAccountMetas,
     },
+    rand::{rngs::StdRng, Rng, SeedableRng},
     solana_program_test::*,
     solana_sdk::{
         clock::Clock, compute_budget::ComputeBudgetInstruction, epoch_schedule::EpochSchedule,
@@ -27,7 +28,7 @@ fn create_copy_cluster_history_transaction(fixture: &TestFixture) -> Transaction
         .to_account_metas(None),
     };
     let heap_request_ix = ComputeBudgetInstruction::request_heap_frame(256 * 1024);
-    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_000_000);
+    let compute_budget_ix = ComputeBudgetInstruction::set_compute_unit_limit(1_400_000);
 
     Transaction::new_signed_with_payer(
         &[heap_request_ix, compute_budget_ix, instruction],
@@ -131,15 +132,15 @@ async fn test_cluster_history_compute_limit() {
     fixture.initialize_config().await;
     fixture.initialize_cluster_history_account().await;
 
-    // Set EpochSchedule with 432,000 slots
+    // Set EpochSchedule with 432,000 slots per epoch
     let epoch_schedule = EpochSchedule::default();
     ctx.borrow_mut().set_sysvar(&epoch_schedule);
 
     fixture
-        .advance_num_epochs(epoch_schedule.first_normal_epoch + 1)
+        .advance_num_epochs(epoch_schedule.first_normal_epoch)
         .await;
     fixture
-        .advance_clock(epoch_schedule.first_normal_epoch + 1, 400)
+        .advance_clock(epoch_schedule.first_normal_epoch, 400)
         .await;
 
     let clock: Clock = ctx
@@ -149,16 +150,39 @@ async fn test_cluster_history_compute_limit() {
         .await
         .expect("clock");
 
+    let mut rng = StdRng::from_seed([42; 32]);
+    let mut prev_epoch_total_blocks = 0;
+    let mut current_epoch_total_blocks = 0;
     // Set SlotHistory sysvar
     let mut slot_history = SlotHistory::default();
     for i in epoch_schedule.get_first_slot_in_epoch(clock.epoch - 1)
+        ..=epoch_schedule.get_last_slot_in_epoch(clock.epoch - 1)
+    {
+        if rng.gen_bool(0.5) {
+            prev_epoch_total_blocks += 1;
+            slot_history.add(i);
+        }
+    }
+    for i in epoch_schedule.get_first_slot_in_epoch(clock.epoch)
         ..=epoch_schedule.get_last_slot_in_epoch(clock.epoch)
     {
-        if i % 2 == 0 {
+        if rng.gen_bool(0.5) {
+            current_epoch_total_blocks += 1;
             slot_history.add(i);
         }
     }
 
+    ctx.borrow_mut()
+        .warp_to_slot(epoch_schedule.get_last_slot_in_epoch(clock.epoch))
+        .unwrap();
+    let mut clock: Clock = ctx
+        .borrow_mut()
+        .banks_client
+        .get_sysvar()
+        .await
+        .expect("clock");
+    clock.slot = epoch_schedule.get_last_slot_in_epoch(clock.epoch);
+    ctx.borrow_mut().set_sysvar(&clock);
     ctx.borrow_mut().set_sysvar(&slot_history);
 
     // Submit instruction
@@ -170,9 +194,9 @@ async fn test_cluster_history_compute_limit() {
         .await;
 
     assert!(account.history.arr[0].epoch as u64 == clock.epoch - 1);
-    assert!(account.history.arr[0].total_blocks == 216_000);
+    assert!(account.history.arr[0].total_blocks == prev_epoch_total_blocks);
     assert!(account.history.arr[1].epoch as u64 == clock.epoch);
-    assert!(account.history.arr[1].total_blocks == 1);
+    assert!(account.history.arr[1].total_blocks == current_epoch_total_blocks);
 }
 
 // Non-fixture test to ensure that the SlotHistory partial slot logic works


### PR DESCRIPTION
Some of the logic around reading partial blocks was slightly off, especially for cases where there are no full blocks in between the start and end slot. Also, making sure we don't read slots past the current slot when updating current epoch. 
