### PR TITLE
Disable rustls warning until upgrade to v1.17 agave

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065
+      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065 --ignore RUSTSEC-2024-0336
 
   lint:
     name: lint


### PR DESCRIPTION
Due to the below error, this package needs to be upgraded, and the old version is pinned in solana dependencies, however none of the solana 1.16 versions will get the upgrade.  This repo will need its dependencies upgraded to v1.17 on the agave once the below PR is merged. Additionally, there may be issues with solana-program-test in 1.17 that will need to be worked out.

https://github.com/anza-xyz/agave/pull/930


```
Run cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 621 security advisories (from /home/runner/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (63[4](https://github.com/jito-foundation/stakenet/actions/runs/8759384154/job/24042265021?pr=31#step:4:5) crate dependencies)
Crate:     rustls
Version:   0.20.9
error: 2 vulnerabilities found!
Title:     `rustls::ConnectionCommon::complete_io` could fall into an infinite loop based on network input
Date:      2024-04-19
ID:        RUSTSEC-2024-0336
URL:       https://rustsec.org/advisories/RUSTSEC-2024-0336
Severity:  7.[5](https://github.com/jito-foundation/stakenet/actions/runs/8759384154/job/24042265021?pr=31#step:4:6) (high)
Solution:  Upgrade to >=0.23.5 OR >=0.22.4, <0.23.0 OR >=0.21.11, <0.22.0
```