### PR TITLE
FEATURE: Adding metrics - num_get_vote_accounts_voting, num_live_validator_histories

### DIFF
--- a/keepers/validator-keeper/src/lib.rs
+++ b/keepers/validator-keeper/src/lib.rs
@@ -208,8 +208,7 @@ pub async fn emit_validator_history_metrics(
     let vote_program_id = get_vote_program_id();
     let live_validator_histories_count =
         get_multiple_accounts_batched(&all_history_vote_accounts, client)
-            .await
-            .expect("Cannot fetch validator history vote accounts")
+            .await?
             .iter()
             .filter(|&account| {
                 account


### PR DESCRIPTION
Added two new metrics to the `emit_validator_history_metrics` function:

- `num_live_validator_histories`: The number of validator history accounts that have "live" vote accounts with the owner of said vote account being the vote program
- `num_get_vote_accounts_voting`: The number of vote accounts actually voting. More specifically, accounts that have voted in the current epoch retrieved from `get_vote_accounts_with_retry`. 