### PR TITLE
Insert missing entries in CopyVoteAccount

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,3 @@ members = [
   "tests",
   "utils/*"
 ]
-
-[profile.release]
-overflow-checks = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ members = [
   "tests",
   "utils/*"
 ]
+
+[profile.release]
+overflow-checks = true

--- a/programs/validator-history/idl/validator_history.json
+++ b/programs/validator-history/idl/validator_history.json
@@ -954,6 +954,11 @@
       "code": 6011,
       "name": "EpochTooLarge",
       "msg": "Epoch larger than 65535, cannot be stored"
+    },
+    {
+      "code": 6012,
+      "name": "DuplicateEpoch",
+      "msg": "Inserting duplicate epoch"
     }
   ]
 }

--- a/programs/validator-history/idl/validator_history.json
+++ b/programs/validator-history/idl/validator_history.json
@@ -903,7 +903,7 @@
     {
       "code": 6001,
       "name": "InvalidEpochCredits",
-      "msg": "Invalid epoch credits, credits must be greater than previous credits"
+      "msg": "Invalid epoch credits, credits must exist and each value must be greater than previous credits"
     },
     {
       "code": 6002,
@@ -928,7 +928,7 @@
     {
       "code": 6006,
       "name": "NotEnoughVotingHistory",
-      "msg": "Not enough voting history to create account. Minimum 10 epochs required"
+      "msg": "Not enough voting history to create account. Minimum 5 epochs required"
     },
     {
       "code": 6007,

--- a/programs/validator-history/src/errors.rs
+++ b/programs/validator-history/src/errors.rs
@@ -5,7 +5,7 @@ pub enum ValidatorHistoryError {
     #[msg("Account already reached proper size, no more allocations allowed")]
     AccountFullySized,
     #[msg(
-        "Invalid epoch credits, credits exist and each value must be greater than previous credits"
+        "Invalid epoch credits, credits must exist and each value must be greater than previous credits"
     )]
     InvalidEpochCredits,
     #[msg("Epoch is out of range of history")]

--- a/programs/validator-history/src/errors.rs
+++ b/programs/validator-history/src/errors.rs
@@ -28,4 +28,6 @@ pub enum ValidatorHistoryError {
     SlotHistoryOutOfDate,
     #[msg("Epoch larger than 65535, cannot be stored")]
     EpochTooLarge,
+    #[msg("Inserting duplicate epoch")]
+    DuplicateEpoch,
 }

--- a/programs/validator-history/src/errors.rs
+++ b/programs/validator-history/src/errors.rs
@@ -4,7 +4,9 @@ use anchor_lang::prelude::*;
 pub enum ValidatorHistoryError {
     #[msg("Account already reached proper size, no more allocations allowed")]
     AccountFullySized,
-    #[msg("Invalid epoch credits, credits must be greater than previous credits")]
+    #[msg(
+        "Invalid epoch credits, credits exist and each value must be greater than previous credits"
+    )]
     InvalidEpochCredits,
     #[msg("Epoch is out of range of history")]
     EpochOutOfRange,
@@ -14,7 +16,7 @@ pub enum ValidatorHistoryError {
     GossipDataInvalid,
     #[msg("Unsupported IP Format, only IpAddr::V4 is supported")]
     UnsupportedIpFormat,
-    #[msg("Not enough voting history to create account. Minimum 10 epochs required")]
+    #[msg("Not enough voting history to create account. Minimum 5 epochs required")]
     NotEnoughVotingHistory,
     #[msg(
         "Gossip data too old. Data cannot be older than the last recorded timestamp for a field"

--- a/programs/validator-history/src/instructions/copy_vote_account.rs
+++ b/programs/validator-history/src/instructions/copy_vote_account.rs
@@ -31,6 +31,7 @@ pub fn handle_copy_vote_account(ctx: Context<CopyVoteAccount>) -> Result<()> {
     validator_history_account.set_commission_and_slot(epoch, commission, clock.slot)?;
 
     let epoch_credits = VoteStateVersions::deserialize_epoch_credits(&ctx.accounts.vote_account)?;
+    validator_history_account.insert_missing_entries(&epoch_credits)?;
     validator_history_account.set_epoch_credits(&epoch_credits)?;
 
     Ok(())

--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -442,12 +442,13 @@ impl ValidatorHistory {
             }));
 
         for (entry_is_some, epoch) in entries.iter().zip(start_epoch as u16..=end_epoch) {
-            if !*entry_is_some && epoch_credits_map.get(&epoch).is_some() {
+            if !*entry_is_some && epoch_credits_map.contains_key(&epoch) {
+                // Inserts blank entry that will have credits copied to it later
                 let entry = ValidatorHistoryEntry {
                     epoch,
                     ..ValidatorHistoryEntry::default()
                 };
-                // If entry cannot be inserted, skips
+                // Skips if epoch is out of range or duplicate
                 self.history.insert(entry, epoch).unwrap_or_default();
             }
         }

--- a/programs/validator-history/src/utils.rs
+++ b/programs/validator-history/src/utils.rs
@@ -15,6 +15,38 @@ pub fn cast_epoch(epoch: u64) -> Result<u16> {
     Ok(epoch_u16)
 }
 
+pub fn get_min_epoch(
+    epoch_credits: &[(
+        u64, /* epoch */
+        u64, /* epoch cumulative votes */
+        u64, /* prev epoch cumulative votes */
+    )],
+) -> Result<u16> {
+    cast_epoch(
+        epoch_credits
+            .iter()
+            .min_by_key(|(epoch, _, _)| *epoch)
+            .ok_or(ValidatorHistoryError::InvalidEpochCredits)?
+            .0,
+    )
+}
+
+pub fn get_max_epoch(
+    epoch_credits: &[(
+        u64, /* epoch */
+        u64, /* epoch cumulative votes */
+        u64, /* prev epoch cumulative votes */
+    )],
+) -> Result<u16> {
+    cast_epoch(
+        epoch_credits
+            .iter()
+            .max_by_key(|(epoch, _, _)| *epoch)
+            .ok_or(ValidatorHistoryError::InvalidEpochCredits)?
+            .0,
+    )
+}
+
 pub fn cast_epoch_start_timestamp(start_timestamp: i64) -> u64 {
     start_timestamp.try_into().unwrap()
 }

--- a/programs/validator-history/src/utils.rs
+++ b/programs/validator-history/src/utils.rs
@@ -57,12 +57,10 @@ pub fn find_insert_position(
             let mut right = len;
             while left < right {
                 let mid = (left + right) / 2;
-                if arr[mid].epoch == epoch {
-                    return None;
-                } else if arr[mid].epoch < epoch {
-                    left = mid + 1;
-                } else {
-                    right = mid;
+                match arr[mid].epoch.cmp(&epoch) {
+                    std::cmp::Ordering::Equal => return None,
+                    std::cmp::Ordering::Less => left = mid + 1,
+                    std::cmp::Ordering::Greater => right = mid,
                 }
             }
             left % arr.len()
@@ -74,12 +72,10 @@ pub fn find_insert_position(
                 let mid = (left + right) / 2;
                 // idx + 1 is the index of the smallest epoch in the array
                 let mid_idx = ((idx + 1) + mid) % len;
-                if arr[mid_idx].epoch == epoch {
-                    return None;
-                } else if arr[mid_idx].epoch < epoch {
-                    left = mid + 1;
-                } else {
-                    right = mid;
+                match arr[mid_idx].epoch.cmp(&epoch) {
+                    std::cmp::Ordering::Equal => return None,
+                    std::cmp::Ordering::Less => left = mid + 1,
+                    std::cmp::Ordering::Greater => right = mid,
                 }
             }
             ((idx + 1) + left) % len

--- a/programs/validator-history/src/utils.rs
+++ b/programs/validator-history/src/utils.rs
@@ -43,7 +43,6 @@ pub fn find_insert_position(
     idx: usize,
     epoch: u16,
 ) -> Option<usize> {
-    // Pseudo-binary search to find position
     let len = arr.len();
     if len == 0 {
         return None;

--- a/tests/tests/test_vote_account.rs
+++ b/tests/tests/test_vote_account.rs
@@ -1,8 +1,11 @@
 #![allow(clippy::await_holding_refcell_ref)]
-use anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas};
+use anchor_lang::{
+    solana_program::instruction::Instruction, AnchorSerialize, Discriminator, InstructionData,
+    ToAccountMetas,
+};
 use solana_program_test::*;
 use solana_sdk::{
-    clock::Clock, compute_budget::ComputeBudgetInstruction, signer::Signer,
+    account::Account, clock::Clock, compute_budget::ComputeBudgetInstruction, signer::Signer,
     transaction::Transaction, vote::state::MAX_EPOCH_CREDITS_HISTORY,
 };
 use tests::fixtures::{new_vote_account, TestFixture};
@@ -264,6 +267,113 @@ async fn test_insert_missing_entries_compute() {
             account.history.arr[i].epoch_credits == ValidatorHistoryEntry::default().epoch_credits
         );
         assert!(account.history.arr[i].commission == ValidatorHistoryEntry::default().commission);
+    }
+
+    drop(fixture);
+}
+
+fn serialized_validator_history_account(validator_history: ValidatorHistory) -> Account {
+    let mut data = vec![];
+    validator_history.serialize(&mut data).unwrap();
+    for byte in ValidatorHistory::discriminator().into_iter().rev() {
+        data.insert(0, byte);
+    }
+    Account {
+        lamports: 1_000_000_000,
+        data,
+        owner: validator_history::id(),
+        ..Account::default()
+    }
+}
+
+#[tokio::test]
+async fn test_insert_missing_entries_wraparound() {
+    // initialize validator history account with > 600 epochs of entries, missing one. This will force wraparound
+    //
+    // initialize vote account with 64 epochs, filling in the missing one
+
+    let fixture = TestFixture::new().await;
+    let ctx = &fixture.ctx;
+    fixture.initialize_config().await;
+    fixture.initialize_validator_history_account().await;
+
+    fixture.advance_num_epochs(610).await;
+
+    let mut validator_history: ValidatorHistory = fixture
+        .load_and_deserialize(&fixture.validator_history_account)
+        .await;
+
+    // Fill in 600 epochs of entries, skipping 590
+    // This will create wraparound, storing epochs 87 - 599
+    for i in 0..600 {
+        if i == 590 {
+            continue;
+        }
+        validator_history.history.push(ValidatorHistoryEntry {
+            epoch: i as u16,
+            epoch_credits: 10,
+            commission: 9,
+            vote_account_last_update_slot: 0,
+            ..Default::default()
+        });
+    }
+
+    ctx.borrow_mut().set_account(
+        &fixture.validator_history_account,
+        &serialized_validator_history_account(validator_history).into(),
+    );
+
+    // New vote account with epochs 580 - 610
+    // 11 credits per epoch
+    let epoch_credits: Vec<(u64, u64, u64)> = (580..611).map(|i| (i, 11, 0)).collect();
+
+    let vote_account = new_vote_account(
+        fixture.vote_account,
+        fixture.vote_account,
+        10,
+        Some(epoch_credits.clone()),
+    );
+
+    ctx.borrow_mut()
+        .set_account(&fixture.vote_account, &vote_account.into());
+
+    let instruction = Instruction {
+        program_id: validator_history::id(),
+        data: validator_history::instruction::CopyVoteAccount {}.data(),
+        accounts: validator_history::accounts::CopyVoteAccount {
+            validator_history_account: fixture.validator_history_account,
+            vote_account: fixture.vote_account,
+            signer: fixture.keypair.pubkey(),
+        }
+        .to_account_metas(None),
+    };
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&fixture.keypair.pubkey()),
+        &[&fixture.keypair],
+        ctx.borrow().last_blockhash,
+    );
+    fixture.submit_transaction_assert_success(transaction).await;
+
+    let account: ValidatorHistory = fixture
+        .load_and_deserialize(&fixture.validator_history_account)
+        .await;
+
+    // 610 % 512 == 98
+    assert_eq!(account.history.idx, 98);
+
+    // Ensures that all entries exist, including missing 590
+    // and entries 600 - 610 inserted after last entry
+    // And that epoch credits were updated properly
+    for i in account.history.idx as usize + 1..611 {
+        let index = i % ValidatorHistory::MAX_ITEMS;
+        assert_eq!(account.history.arr[index].epoch, i as u16,);
+        if i >= 580 {
+            assert_eq!(account.history.arr[index].epoch_credits, 11);
+        } else {
+            assert_eq!(account.history.arr[index].epoch_credits, 10);
+        }
     }
 
     drop(fixture);

--- a/tests/tests/test_vote_account.rs
+++ b/tests/tests/test_vote_account.rs
@@ -1,5 +1,4 @@
 #![allow(clippy::await_holding_refcell_ref)]
-
 use anchor_lang::{solana_program::instruction::Instruction, InstructionData, ToAccountMetas};
 use solana_program_test::*;
 use solana_sdk::{


### PR DESCRIPTION
Problem: 
Due to unreliability in landing transactions in epoch 598 (when chain was super congested), about half of active validators did not get a single ValidatorHistoryEntry created, so their epoch credits were never copied over in future epochs. This is bad for Stakenet scoring, and this issue could happen in the future if congestion gets bad again.

Solution:
In the CopyVoteAccount instruction, when epochs are detected in the vote account that don't exist in the CircBuf, insert those new entries and shift all entries with greater epochs forward by one. This will evict the oldest entries if we are wrapping around. After that, epoch credits are copied to the old entries. We will then be able to retroactively call:
`CopyTipDistributionAccount` and `UpdateStakeHistory` on those validators. 

Notes:
* We are still within the 64 epoch vote credit range, so epoch credits from 598 and any other randomly skipped entries will get added
* In the most extreme case possible of 64 entries inserted (max epochs in vote account), this instruction uses ~270k CUs. Most of the time none will be added, and when this first runs, a handful will be added for some validators. Normal CU usage is <30k.