### PR TITLE
FIX: Fixed instant removal validator stuck scenario

### DIFF
--- a/programs/steward/idl/steward.json
+++ b/programs/steward/idl/steward.json
@@ -1810,6 +1810,11 @@
       "code": 6029,
       "name": "ValidatorNeedsToBeMarkedForRemoval",
       "msg": "Validator needs to be marked for removal"
+    },
+    {
+      "code": 6030,
+      "name": "InvalidStakeState",
+      "msg": "Invalid stake state"
     }
   ],
   "types": [

--- a/programs/steward/src/errors.rs
+++ b/programs/steward/src/errors.rs
@@ -64,4 +64,6 @@ pub enum StewardError {
     VoteAccountDoesNotMatch,
     #[msg("Validator needs to be marked for removal")]
     ValidatorNeedsToBeMarkedForRemoval,
+    #[msg("Invalid stake state")]
+    InvalidStakeState,
 }

--- a/programs/steward/src/instructions/instant_remove_validator.rs
+++ b/programs/steward/src/instructions/instant_remove_validator.rs
@@ -39,7 +39,8 @@ pub fn handler(
     let mut state_account = ctx.accounts.state_account.load_mut()?;
 
     let clock = Clock::get()?;
-    let validators_to_remove = state_account.state.validators_for_immediate_removal.count();
+    let validators_for_immediate_removal =
+        state_account.state.validators_for_immediate_removal.count();
     let validators_in_list = get_validator_list_length(&ctx.accounts.validator_list)?;
 
     require!(
@@ -64,7 +65,8 @@ pub fn handler(
 
     let total_deactivating = stake_status_tally.deactivating_all
         + stake_status_tally.deactivating_transient
-        + stake_status_tally.deactivating_validator;
+        + stake_status_tally.deactivating_validator
+        + stake_status_tally.ready_for_removal;
 
     require!(
         total_deactivating == state_account.state.validators_to_remove.count() as u64,
@@ -79,7 +81,7 @@ pub fn handler(
     require!(
         state_account.state.num_pool_validators as usize
             + state_account.state.validators_added as usize
-            - validators_to_remove
+            - validators_for_immediate_removal
             == validators_in_list,
         StewardError::ListStateMismatch
     );


### PR DESCRIPTION
The issue is that if 2 validators are put into `DeactivatingValidator` one marked for instant removal and the other for regular removal. The function `instant_remove_validator` will not be able to run, halting the state machine for the epoch. This is because `instant_remove_validator` is checking to see that all validators are not in `DeactivatingValidator` or `ReadyForRemoval`. However since the discovery that regular removals can also go directly to `DeactivatingValidator` this check is no longer valid.

The fix is to tally all of the deactivating StakeStatus across the validator list and assert that the count is equal to the regular removed validators, then we can safely assume all of the immediate to remove validators are already removed from the list.