### PR TITLE
Force state transitions to Idle before doing work in new epoch

### DIFF
--- a/programs/steward/src/instructions/compute_instant_unstake.rs
+++ b/programs/steward/src/instructions/compute_instant_unstake.rs
@@ -42,6 +42,17 @@ pub fn handler(ctx: Context<ComputeInstantUnstake>, validator_list_index: usize)
     let clock = Clock::get()?;
     let epoch_schedule = EpochSchedule::get()?;
 
+    // Transitions to Idle before doing compute_instant_unstake if RESET_TO_IDLE is set
+    if let Some(event) = maybe_transition(
+        &mut state_account.state,
+        &clock,
+        &config.parameters,
+        &epoch_schedule,
+    )? {
+        emit!(event);
+        return Ok(());
+    }
+
     state_checks(
         &clock,
         &config,

--- a/programs/steward/src/instructions/rebalance.rs
+++ b/programs/steward/src/instructions/rebalance.rs
@@ -164,7 +164,6 @@ pub fn handler(ctx: Context<Rebalance>, validator_list_index: usize) -> Result<(
             return Ok(());
         }
 
-
         state_checks(
             &clock,
             &config,

--- a/programs/steward/src/instructions/rebalance.rs
+++ b/programs/steward/src/instructions/rebalance.rs
@@ -153,6 +153,18 @@ pub fn handler(ctx: Context<Rebalance>, validator_list_index: usize) -> Result<(
     {
         let mut state_account = ctx.accounts.state_account.load_mut()?;
 
+        // Transitions to Idle before doing rebalance if RESET_TO_IDLE is set
+        if let Some(event) = maybe_transition(
+            &mut state_account.state,
+            &clock,
+            &config.parameters,
+            &epoch_schedule,
+        )? {
+            emit!(event);
+            return Ok(());
+        }
+
+
         state_checks(
             &clock,
             &config,


### PR DESCRIPTION
Currently a single lingering ComputeInstantUnstake or Rebalance step can be executed if the Steward was left in this state after rolling over to a new epoch. This can affect stake based on outdated information which we don't want. Force the transition to Idle so everything is handled normally. 
