### PR TITLE
Blacklist instructions accept multiple validators

### DIFF
--- a/programs/steward/src/instructions/add_validators_to_blacklist.rs
+++ b/programs/steward/src/instructions/add_validators_to_blacklist.rs
@@ -2,7 +2,7 @@ use crate::{utils::get_config_blacklist_authority, Config};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct AddValidatorToBlacklist<'info> {
+pub struct AddValidatorsToBlacklist<'info> {
     #[account(mut)]
     pub config: AccountLoader<'info, Config>,
 
@@ -12,10 +12,10 @@ pub struct AddValidatorToBlacklist<'info> {
 
 // Removes ability for validator to receive delegation. Score will be set to 0 and instant unstaking will occur.
 // Index is the index of the validator from ValidatorHistory.
-pub fn handler(ctx: Context<AddValidatorToBlacklist>, validator_history_index: u32) -> Result<()> {
+pub fn handler(ctx: Context<AddValidatorsToBlacklist>, validator_history_indices: &[u32]) -> Result<()> {
     let mut config = ctx.accounts.config.load_mut()?;
-    config
-        .validator_history_blacklist
-        .set(validator_history_index as usize, true)?;
+    for index in validator_history_indices {
+        config.validator_history_blacklist.set(*index as usize, true)?;
+    }
     Ok(())
 }

--- a/programs/steward/src/instructions/mod.rs
+++ b/programs/steward/src/instructions/mod.rs
@@ -1,5 +1,5 @@
 #![allow(ambiguous_glob_reexports)]
-pub mod add_validator_to_blacklist;
+pub mod add_validators_to_blacklist;
 pub mod admin_mark_for_removal;
 pub mod auto_add_validator_to_pool;
 pub mod auto_remove_validator_from_pool;
@@ -14,7 +14,7 @@ pub mod instant_remove_validator;
 pub mod pause_steward;
 pub mod realloc_state;
 pub mod rebalance;
-pub mod remove_validator_from_blacklist;
+pub mod remove_validators_from_blacklist;
 pub mod reset_steward_state;
 pub mod reset_validator_lamport_balances;
 pub mod resume_steward;
@@ -22,7 +22,7 @@ pub mod set_new_authority;
 pub mod spl_passthrough;
 pub mod update_parameters;
 
-pub use add_validator_to_blacklist::*;
+pub use add_validators_to_blacklist::*;
 pub use admin_mark_for_removal::*;
 pub use auto_add_validator_to_pool::*;
 pub use auto_remove_validator_from_pool::*;
@@ -37,7 +37,7 @@ pub use instant_remove_validator::*;
 pub use pause_steward::*;
 pub use realloc_state::*;
 pub use rebalance::*;
-pub use remove_validator_from_blacklist::*;
+pub use remove_validators_from_blacklist::*;
 pub use reset_steward_state::*;
 pub use reset_validator_lamport_balances::*;
 pub use resume_steward::*;

--- a/programs/steward/src/instructions/remove_validators_from_blacklist.rs
+++ b/programs/steward/src/instructions/remove_validators_from_blacklist.rs
@@ -2,7 +2,7 @@ use crate::{utils::get_config_blacklist_authority, Config};
 use anchor_lang::prelude::*;
 
 #[derive(Accounts)]
-pub struct RemoveValidatorFromBlacklist<'info> {
+pub struct RemoveValidatorsFromBlacklist<'info> {
     #[account(mut)]
     pub config: AccountLoader<'info, Config>,
 
@@ -13,12 +13,12 @@ pub struct RemoveValidatorFromBlacklist<'info> {
 // Removes validator from blacklist. Validator will be eligible to receive delegation again when scores are recomputed.
 // Index is the index of the validator from ValidatorHistory.
 pub fn handler(
-    ctx: Context<RemoveValidatorFromBlacklist>,
-    validator_history_index: u32,
+    ctx: Context<RemoveValidatorsFromBlacklist>,
+    validator_history_indices: &[u32],
 ) -> Result<()> {
     let mut config = ctx.accounts.config.load_mut()?;
-    config
-        .validator_history_blacklist
-        .set(validator_history_index as usize, false)?;
+    for index in validator_history_indices {
+        config.validator_history_blacklist.set(*index as usize, false)?;
+    }
     Ok(())
 }

--- a/programs/steward/src/lib.rs
+++ b/programs/steward/src/lib.rs
@@ -163,20 +163,20 @@ pub mod steward {
         instructions::resume_steward::handler(ctx)
     }
 
-    /// Adds the validator at `index` to the blacklist. It will be instant unstaked and never receive delegations
-    pub fn add_validator_to_blacklist(
-        ctx: Context<AddValidatorToBlacklist>,
-        validator_history_blacklist: u32,
+    /// Adds the validators to the blacklist. They will be instant unstaked and never receive delegations. Each u32 is a ValidatorHistory index.
+    pub fn add_validators_to_blacklist(
+        ctx: Context<AddValidatorsToBlacklist>,
+        validator_history_blacklist: Vec<u32>
     ) -> Result<()> {
-        instructions::add_validator_to_blacklist::handler(ctx, validator_history_blacklist)
+        instructions::add_validators_to_blacklist::handler(ctx, &validator_history_blacklist)
     }
 
-    /// Removes the validator at `index` from the blacklist
-    pub fn remove_validator_from_blacklist(
-        ctx: Context<RemoveValidatorFromBlacklist>,
-        validator_history_blacklist: u32,
+    /// Removes the validators from the blacklist. Each u32 is a ValidatorHistory index.
+    pub fn remove_validators_from_blacklist(
+        ctx: Context<RemoveValidatorsFromBlacklist>,
+        validator_history_blacklist: Vec<u32>
     ) -> Result<()> {
-        instructions::remove_validator_from_blacklist::handler(ctx, validator_history_blacklist)
+        instructions::remove_validators_from_blacklist::handler(ctx, &validator_history_blacklist)
     }
 
     /// For parameters that are present in args, the instruction checks that they are within sensible bounds and saves them to config struct

--- a/tests/tests/steward/test_steward.rs
+++ b/tests/tests/steward/test_steward.rs
@@ -294,13 +294,13 @@ async fn test_blacklist() {
 
     let ix = Instruction {
         program_id: jito_steward::id(),
-        accounts: jito_steward::accounts::AddValidatorToBlacklist {
+        accounts: jito_steward::accounts::AddValidatorsToBlacklist {
             config: fixture.steward_config.pubkey(),
             authority: fixture.keypair.pubkey(),
         }
         .to_account_metas(None),
-        data: jito_steward::instruction::AddValidatorToBlacklist {
-            validator_history_blacklist: 0,
+        data: jito_steward::instruction::AddValidatorsToBlacklist {
+            validator_history_blacklist: vec![0],
         }
         .data(),
     };
@@ -321,13 +321,13 @@ async fn test_blacklist() {
 
     let ix = Instruction {
         program_id: jito_steward::id(),
-        accounts: jito_steward::accounts::RemoveValidatorFromBlacklist {
+        accounts: jito_steward::accounts::RemoveValidatorsFromBlacklist {
             config: fixture.steward_config.pubkey(),
             authority: fixture.keypair.pubkey(),
         }
         .to_account_metas(None),
-        data: jito_steward::instruction::RemoveValidatorFromBlacklist {
-            validator_history_blacklist: 0,
+        data: jito_steward::instruction::RemoveValidatorsFromBlacklist {
+            validator_history_blacklist: vec![0],
         }
         .data(),
     };


### PR DESCRIPTION
Update both adding and removing instructions to take in a Vec<u32> of validator history indices for updating the blacklist. This makes multisig IXs for bulk adding to the blacklist much easier.
