### PR TITLE
Fix for removed validator past boundary

### DIFF
--- a/keepers/stakenet-keeper/src/entries/crank_steward.rs
+++ b/keepers/stakenet-keeper/src/entries/crank_steward.rs
@@ -266,7 +266,7 @@ async fn _handle_instant_removal_validators(
 
     while validators_to_remove.count() != 0 {
         let mut validator_index_to_remove = None;
-        for i in 0..num_validators {
+        for i in 0..all_steward_accounts.validator_list_account.validators.len() as u64 {
             if validators_to_remove.get(i as usize).map_err(|e| {
                 JitoTransactionError::Custom(format!(
                     "Error fetching bitmask index for immediate removed validator: {}/{} - {}",

--- a/programs/steward/src/instructions/epoch_maintenance.rs
+++ b/programs/steward/src/instructions/epoch_maintenance.rs
@@ -85,7 +85,7 @@ pub fn handler(
         if let Some(validator_index_to_remove) = validator_index_to_remove {
             state_account
                 .state
-                .remove_validator(validator_index_to_remove)?;
+                .remove_validator(validator_index_to_remove, validators_in_list)?;
         }
     }
 

--- a/programs/steward/src/instructions/instant_remove_validator.rs
+++ b/programs/steward/src/instructions/instant_remove_validator.rs
@@ -88,7 +88,7 @@ pub fn handler(
 
     state_account
         .state
-        .remove_validator(validator_index_to_remove)?;
+        .remove_validator(validator_index_to_remove, validators_in_list)?;
 
     Ok(())
 }

--- a/programs/steward/src/state/steward_state.rs
+++ b/programs/steward/src/state/steward_state.rs
@@ -537,24 +537,32 @@ impl StewardState {
             }
         }
 
+        // If index is greater than or equal to num_pool_validators, we are removing a validator that is not in the pool
+        // so nothing was shifted above, however we still want to clear the values there
+        let index_to_clear = if index >= num_pool_validators {
+            index
+        } else {
+            num_pool_validators
+        };
+
         // Clear values on empty last index
-        self.validator_lamport_balances[num_pool_validators] = 0;
-        self.scores[num_pool_validators] = 0;
-        self.yield_scores[num_pool_validators] = 0;
-        self.sorted_score_indices[num_pool_validators] = SORTED_INDEX_DEFAULT;
-        self.sorted_yield_score_indices[num_pool_validators] = SORTED_INDEX_DEFAULT;
-        self.delegations[num_pool_validators] = Delegation::default();
-        self.instant_unstake.set(num_pool_validators, false)?;
-        self.progress.set(num_pool_validators, false)?;
-        self.validators_to_remove.set(num_pool_validators, false)?;
+        self.validator_lamport_balances[index_to_clear] = LAMPORT_BALANCE_DEFAULT;
+        self.scores[index_to_clear] = 0;
+        self.yield_scores[index_to_clear] = 0;
+        self.sorted_score_indices[index_to_clear] = SORTED_INDEX_DEFAULT;
+        self.sorted_yield_score_indices[index_to_clear] = SORTED_INDEX_DEFAULT;
+        self.delegations[index_to_clear] = Delegation::default();
+        self.instant_unstake.set(index_to_clear, false)?;
+        self.progress.set(index_to_clear, false)?;
+        self.validators_to_remove.set(index_to_clear, false)?;
         self.validators_for_immediate_removal
-            .set(num_pool_validators, false)?;
+            .set(index_to_clear, false)?;
 
         if marked_for_regular_removal {
-            self.validators_to_remove.set(num_pool_validators, false)?;
+            self.validators_to_remove.set(index_to_clear, false)?;
         } else {
             self.validators_for_immediate_removal
-                .set(num_pool_validators, false)?;
+                .set(index_to_clear, false)?;
         }
 
         Ok(())


### PR DESCRIPTION
Problem: A bug was found where validators who are added to the pool outside of the boundary of the Steward state, then removed before they begin getting tracked (validators added during cycle N are tracked in steward state in cycle N+1) were not getting properly removed. This caused the state machine to get stuck because the invariant used to keep the state aligned was failing (`num_pool_validators + validators_added - validators_to_remove == validator_list.len()`)

Resolution: Make sure we're shifting values for steward state fields that can be relevant past `num_pool_validators` (which is just the validators_to_remove and validators_for_immediate_removal). We also don't want to clear those values at `num_pool_validators` because that might be a relevant value.