### PR TITLE
PATCH: Empty Epoch Credits

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065 --ignore RUSTSEC-2024-0336 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0357
+      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065 --ignore RUSTSEC-2024-0336 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0357 --ignore RUSTSEC-2025-0004 --ignore RUSTSEC-2024-0421
 
   lint:
     name: lint

--- a/keepers/stakenet-keeper/src/entries/crank_steward.rs
+++ b/keepers/stakenet-keeper/src/entries/crank_steward.rs
@@ -132,6 +132,14 @@ pub fn _get_update_stake_pool_ixs(
                 let vote_account = VoteState::deserialize(&raw_vote_account.data)
                     .expect("Could not deserialize vote account");
 
+                if vote_account.epoch_credits.iter().last().is_none() {
+                    println!(
+                        "🆘 ⁉️ Error: Epoch credits has no entries? \nStake Account\n{:?}\nVote Account\n{:?}\n",
+                        stake_account,
+                        vote_account
+                    );
+                    return false;
+                }
                 let latest_epoch = vote_account.epoch_credits.iter().last().unwrap().0;
 
                 match stake_account {

--- a/keepers/stakenet-keeper/src/entries/crank_steward.rs
+++ b/keepers/stakenet-keeper/src/entries/crank_steward.rs
@@ -138,21 +138,22 @@ pub fn _get_update_stake_pool_ixs(
                         stake_account,
                         vote_account
                     );
-                    return false;
-                }
-                let latest_epoch = vote_account.epoch_credits.iter().last().unwrap().0;
+                    false
+                } else {
+                    let latest_epoch = vote_account.epoch_credits.iter().last().unwrap().0;
 
-                match stake_account {
-                    StakeStateV2::Stake(_meta, stake, _stake_flags) => {
-                        if stake.delegation.deactivation_epoch != std::u64::MAX {
-                            false
-                        } else {
-                            latest_epoch <= epoch - 5
+                    match stake_account {
+                        StakeStateV2::Stake(_meta, stake, _stake_flags) => {
+                            if stake.delegation.deactivation_epoch != std::u64::MAX {
+                                false
+                            } else {
+                                latest_epoch <= epoch - 5
+                            }
                         }
-                    }
-                    _ => {
-                        println!("🔶 Error: Stake account is not StakeStateV2::Stake");
-                        false
+                        _ => {
+                            println!("🔶 Error: Stake account is not StakeStateV2::Stake");
+                            false
+                        }
                     }
                 }
             }


### PR DESCRIPTION
There was a keeper crash because it unwrapped an empty epoch credits list.  