### PR TITLE
Keeper: use hostname + region in metrics host id

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,9 +28,9 @@ jobs:
               --ignore RUSTSEC-2024-0344 \
               --ignore RUSTSEC-2024-0421 \
               --ignore RUSTSEC-2025-0022 \
-              --ignore RUSTSEC-2025-0009 \ # TODO(JIT-2364): Remove
-              --ignore RUSTSEC-2025-0004 \ # TODO(JIT-2364): Remove
-              --ignore RUSTSEC-2024-0357   # TODO(JIT-2364): Remove
+              --ignore RUSTSEC-2025-0009 \
+              --ignore RUSTSEC-2025-0004 \
+              --ignore RUSTSEC-2024-0357
 
   lint:
     name: lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,14 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2023-0065 --ignore RUSTSEC-2024-0336 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0357 --ignore RUSTSEC-2025-0004 --ignore RUSTSEC-2024-0421
+      - run: cargo audit \
+              --ignore RUSTSEC-2022-0093 \
+              --ignore RUSTSEC-2024-0344 \
+              --ignore RUSTSEC-2024-0421 \
+              --ignore RUSTSEC-2025-0022 \
+              --ignore RUSTSEC-2025-0009 \ # TODO(JIT-2364): Remove
+              --ignore RUSTSEC-2025-0004 \ # TODO(JIT-2364): Remove
+              --ignore RUSTSEC-2024-0357   # TODO(JIT-2364): Remove
 
   lint:
     name: lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,14 +23,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - run: cargo audit \
-              --ignore RUSTSEC-2022-0093 \
-              --ignore RUSTSEC-2024-0344 \
-              --ignore RUSTSEC-2024-0421 \
-              --ignore RUSTSEC-2025-0022 \
-              --ignore RUSTSEC-2025-0009 \
-              --ignore RUSTSEC-2025-0004 \
-              --ignore RUSTSEC-2024-0357
+      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2025-0004 --ignore RUSTSEC-2024-0357
 
   lint:
     name: lint

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,7 +23,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-audit
-      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2025-0004 --ignore RUSTSEC-2024-0357
+      - run: cargo audit --ignore RUSTSEC-2022-0093 --ignore RUSTSEC-2024-0344 --ignore RUSTSEC-2024-0421 --ignore RUSTSEC-2025-0022 --ignore RUSTSEC-2025-0009 --ignore RUSTSEC-2025-0004 --ignore RUSTSEC-2024-0357 --ignore RUSTSEC-2024-0336
 
   lint:
     name: lint

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ services:
     build:
       context: .
       target: validator-history
-    container_name: stakenet-keeper
     environment:
       - RUST_LOG=${RUST_LOG:-info}
       - SOLANA_METRICS_CONFIG=${SOLANA_METRICS_CONFIG}
@@ -36,6 +35,8 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
+    deploy:
+      replicas: 2
 
   metrics-only:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -35,8 +35,6 @@ services:
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5
-    deploy:
-      replicas: 2
 
   metrics-only:
     build:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
       - PAY_FOR_NEW_ACCOUNTS=${PAY_FOR_NEW_ACCOUNTS}
       - COOL_DOWN_RANGE=${COOL_DOWN_RANGE}
       - GOSSIP_ENTRYPOINT=${GOSSIP_ENTRYPOINT}
+      - REGION=${REGION}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5

--- a/keeper-bot-quick-start.md
+++ b/keeper-bot-quick-start.md
@@ -30,6 +30,9 @@ JSON_RPC_URL="INCLUDE YOUR RPC URL HERE"
 # Cluster to specify (mainnet, testnet, devnet)
 CLUSTER=mainnet
 
+# Region to specify for metrics purposes (us-east, eu-west, local, etc.)
+REGION=local
+
 # Log levels
 RUST_LOG="info,solana_gossip=error,solana_metrics=info"
 

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -299,7 +299,7 @@ async fn main() {
         .trim()
         .to_string();
 
-    set_host_id(format!("{}_{}", args.cluster, hostname));
+    set_host_id(format!("stakenet-keeper_{}_{}", args.cluster, hostname));
 
     let client = Arc::new(RpcClient::new_with_timeout(
         args.json_rpc_url.clone(),

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -299,7 +299,7 @@ async fn main() {
         .trim()
         .to_string();
 
-    set_host_id(format!("stakenet-keeper_{}_{}", args.cluster, hostname));
+    set_host_id(format!("stakenet-keeper_{}_{}_{}", args.region, args.cluster, hostname));
 
     let client = Arc::new(RpcClient::new_with_timeout(
         args.json_rpc_url.clone(),

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -299,7 +299,10 @@ async fn main() {
         .trim()
         .to_string();
 
-    set_host_id(format!("stakenet-keeper_{}_{}_{}", args.region, args.cluster, hostname));
+    set_host_id(format!(
+        "stakenet-keeper_{}_{}_{}",
+        args.region, args.cluster, hostname
+    ));
 
     let client = Arc::new(RpcClient::new_with_timeout(
         args.json_rpc_url.clone(),

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -21,7 +21,7 @@ use stakenet_keeper::{
         update_state::{create_missing_accounts, post_create_update, pre_create_update},
     },
 };
-use std::{sync::Arc, time::Duration};
+use std::{process::Command, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 fn set_run_flags(args: &Args) -> u32 {
@@ -291,7 +291,15 @@ async fn main() {
 
     info!("{}\n\n", args.to_string());
 
-    set_host_id(format!("{}", args.cluster));
+    let hostname_cmd = Command::new("hostname")
+        .output()
+        .expect("Failed to execute hostname command");
+
+    let hostname = String::from_utf8_lossy(&hostname_cmd.stdout)
+        .trim()
+        .to_string();
+
+    set_host_id(format!("{}_{}", args.cluster, hostname));
 
     let client = Arc::new(RpcClient::new_with_timeout(
         args.json_rpc_url.clone(),

--- a/keepers/stakenet-keeper/src/state/keeper_config.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_config.rs
@@ -152,6 +152,10 @@ pub struct Args {
     #[arg(long, env, default_value = "false")]
     pub pay_for_new_accounts: bool,
 
+    /// Pay for the creation of new accounts when needed
+    #[arg(long, env, default_value = "local")]
+    pub region: String,
+
     /// DEBUGGING Changes the random cool down range ( minutes )
     #[arg(long, env, default_value = "20")]
     pub cool_down_range: u8,
@@ -190,6 +194,7 @@ impl fmt::Display for Args {
             No Pack: {}\n\
             Pay for New Accounts: {}\n\
             Cool Down Range: {} minutes\n\
+            Region: {}\n\
             -------------------------------",
             self.json_rpc_url,
             self.gossip_entrypoint,
@@ -217,7 +222,8 @@ impl fmt::Display for Args {
             self.full_startup,
             self.no_pack,
             self.pay_for_new_accounts,
-            self.cool_down_range
+            self.cool_down_range,
+            self.region,
         )
     }
 }


### PR DESCRIPTION
**Problem**
We would like to scale up our keeper instances for redundancy purposes but lack the necessary changes to differentiate between replicas of a service from a metrics perspective.

**Solution**
- Use the `HOSTNAME` env var as a component of the `solana_metrics` `host_id` to differentiate between replicas in our monitoring systems
- Use `REGION` env var as a component of the `solana_metrics` `host_id` for triage purposes
- Ignore RUSTSEC-2025-0022 - this has been ignored upstream

**Local Run Log Output**
See `solana_metrics::metrics host id`

```
[2025-04-07T23:10:57Z INFO  stakenet_keeper] Stakenet Keeper Configuration:
    -------------------------------
    JSON RPC URL: INCLUDE YOUR RPC URL HERE
    Gossip Entrypoint: None
    Keypair Path: "./credentials/keypair.json"
    Oracle Authority Keypair Path: Some("./credentials/oracle_authority.json")
    Validator History Program ID: HistoryJTGbKQD2mRgLZ3XhqHnN811Qpez8X9kCcGHoa
    Tip Distribution Program ID: 4R3gSG8BpU4t19KYj8CfnbtRpnT8gtk4dvTHxVRwc2r7
    Steward Program ID: Stewardf95sJbmtcZsyagb2dg4Mo8eVQho8gpECvLx8
    Steward Config: jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv
    Validator History Interval: 300 seconds
    Steward Interval: 301 seconds
    Metrics Interval: 60 seconds
    Priority Fees: 20000 microlamports
    Retry Count: 100
    Confirmation Seconds: 30
    Cluster: Mainnet
    Run Cluster History: true
    Run Copy Vote Accounts: true
    Run MEV Commission: true
    Run MEV Earned: true
    Run Stake Upload: false
    Run Gossip Upload: false
    Run Steward: true
    Run Emit Metrics: false
    Full Startup: true
    No Pack: false
    Pay for New Accounts: false
    Cool Down Range: 20 minutes
    Region: localhost
    -------------------------------
    
    
[2025-04-07T23:10:57Z INFO  solana_metrics::metrics] host id: stakenet-keeper_localhost_mainnet_Erics-MBP.MG8702
```