### PR TITLE
keeper: Add a cluster tag to emitted metrics

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
+          version: "1.0.9"
       - run: cargo +nightly-2024-02-04 sort --workspace --check
       - run: cargo +nightly-2024-02-04 fmt --all --check
       - run: cargo +nightly-2024-02-04 clippy --all-features --all-targets --tests -- -D warnings

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
       - RUN_STAKE_UPLOAD=false
       - RUN_GOSSIP_UPLOAD=false
       - RUN_EMIT_METRICS=true
+      - REGION=${REGION}
     volumes:
       - ./credentials:/credentials
     restart: on-failure:5

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -104,6 +104,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
 
     // Stateful data
     let mut keeper_state = KeeperState::default();
+    keeper_state.cluster = keeper_config.cluster.to_string();
 
     let smallest_interval = intervals.iter().min().unwrap();
     let mut tick: u64 = *smallest_interval; // 1 second ticks - start at metrics interval

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -104,7 +104,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
 
     // Stateful data
     let mut keeper_state = KeeperState::default();
-    keeper_state.cluster = keeper_config.cluster.to_string();
+    keeper_state.set_cluster_name(&keeper_config.cluster_name);
 
     let smallest_interval = intervals.iter().min().unwrap();
     let mut tick: u64 = *smallest_interval; // 1 second ticks - start at metrics interval
@@ -253,7 +253,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
             keeper_state.set_runs_errors_and_txs_for_epoch(operations::metrics_emit::fire(
                 &keeper_config,
                 &keeper_state,
-                keeper_config.cluster.to_string(),
+                keeper_config.cluster_name.as_str(),
             ));
         }
 
@@ -265,10 +265,13 @@ async fn run_keeper(keeper_config: KeeperConfig) {
                 &keeper_state.runs_for_epoch,
                 &keeper_state.errors_for_epoch,
                 &keeper_state.txs_for_epoch,
-                keeper_config.cluster.to_string(),
+                keeper_config.cluster_name.as_str(),
             );
 
-            KeeperCreates::emit(&keeper_state.created_accounts_for_epoch, keeper_state.cluster.to_string());
+            KeeperCreates::emit(
+                &keeper_state.created_accounts_for_epoch,
+                &keeper_state.cluster_name,
+            );
         }
 
         // ---------- CLEAR STARTUP ----------
@@ -348,7 +351,7 @@ async fn main() {
         cool_down_range: args.cool_down_range,
         tx_retry_count: args.tx_retry_count,
         tx_confirmation_seconds: args.tx_confirmation_seconds,
-        cluster: args.cluster,
+        cluster_name: args.cluster.to_string(),
     };
 
     run_keeper(config).await;

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -265,9 +265,10 @@ async fn run_keeper(keeper_config: KeeperConfig) {
                 &keeper_state.runs_for_epoch,
                 &keeper_state.errors_for_epoch,
                 &keeper_state.txs_for_epoch,
+                keeper_config.cluster.to_string(),
             );
 
-            KeeperCreates::emit(&keeper_state.created_accounts_for_epoch);
+            KeeperCreates::emit(&keeper_state.created_accounts_for_epoch, keeper_state.cluster.to_string());
         }
 
         // ---------- CLEAR STARTUP ----------

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -252,6 +252,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
             keeper_state.set_runs_errors_and_txs_for_epoch(operations::metrics_emit::fire(
                 &keeper_config,
                 &keeper_state,
+                keeper_config.cluster.to_string(),
             ));
         }
 
@@ -345,6 +346,7 @@ async fn main() {
         cool_down_range: args.cool_down_range,
         tx_retry_count: args.tx_retry_count,
         tx_confirmation_seconds: args.tx_confirmation_seconds,
+        cluster: args.cluster,
     };
 
     run_keeper(config).await;

--- a/keepers/stakenet-keeper/src/operations/keeper_operations.rs
+++ b/keepers/stakenet-keeper/src/operations/keeper_operations.rs
@@ -8,7 +8,7 @@ pub enum KeeperCreates {
 impl KeeperCreates {
     pub const LEN: usize = 1;
 
-    pub fn emit(created_accounts_for_epoch: &[u64; KeeperCreates::LEN], cluster: String) {
+    pub fn emit(created_accounts_for_epoch: &[u64; KeeperCreates::LEN], cluster: &str) {
         let aggregate_creates = created_accounts_for_epoch.iter().sum::<u64>();
 
         datapoint_info!(
@@ -60,7 +60,7 @@ impl KeeperOperations {
         runs_for_epoch: &[u64; KeeperOperations::LEN],
         errors_for_epoch: &[u64; KeeperOperations::LEN],
         txs_for_epoch: &[u64; KeeperOperations::LEN],
-        cluster: String,
+        cluster: &str,
     ) {
         let aggregate_actions = runs_for_epoch.iter().sum::<u64>();
         let aggregate_errors = errors_for_epoch.iter().sum::<u64>();

--- a/keepers/stakenet-keeper/src/operations/keeper_operations.rs
+++ b/keepers/stakenet-keeper/src/operations/keeper_operations.rs
@@ -8,7 +8,7 @@ pub enum KeeperCreates {
 impl KeeperCreates {
     pub const LEN: usize = 1;
 
-    pub fn emit(created_accounts_for_epoch: &[u64; KeeperCreates::LEN]) {
+    pub fn emit(created_accounts_for_epoch: &[u64; KeeperCreates::LEN], cluster: String) {
         let aggregate_creates = created_accounts_for_epoch.iter().sum::<u64>();
 
         datapoint_info!(
@@ -21,6 +21,7 @@ impl KeeperCreates {
                 created_accounts_for_epoch[KeeperCreates::CreateValidatorHistory as usize],
                 i64
             ),
+            "cluster" => cluster,
         );
     }
 }
@@ -59,6 +60,7 @@ impl KeeperOperations {
         runs_for_epoch: &[u64; KeeperOperations::LEN],
         errors_for_epoch: &[u64; KeeperOperations::LEN],
         txs_for_epoch: &[u64; KeeperOperations::LEN],
+        cluster: String,
     ) {
         let aggregate_actions = runs_for_epoch.iter().sum::<u64>();
         let aggregate_errors = errors_for_epoch.iter().sum::<u64>();
@@ -246,6 +248,7 @@ impl KeeperOperations {
                 txs_for_epoch[KeeperOperations::Steward as usize],
                 i64
             ),
+            "cluster" => cluster,
         );
     }
 }

--- a/keepers/stakenet-keeper/src/operations/metrics_emit.rs
+++ b/keepers/stakenet-keeper/src/operations/metrics_emit.rs
@@ -417,6 +417,7 @@ pub fn emit_steward_stats(keeper_state: &KeeperState, cluster: String) -> Result
         ),
         ("minimum_stake_lamports", minimum_stake_lamports, i64),
         ("minimum_voting_epochs", minimum_voting_epochs, i64),
+        ("cluster", cluster, String),
     );
 
     Ok(())

--- a/keepers/stakenet-keeper/src/operations/metrics_emit.rs
+++ b/keepers/stakenet-keeper/src/operations/metrics_emit.rs
@@ -23,16 +23,17 @@ fn _should_run() -> bool {
     true
 }
 
-fn _process(keeper_state: &KeeperState) -> Result<(), Box<dyn std::error::Error>> {
-    emit_validator_history_metrics(keeper_state)?;
-    emit_keeper_stats(keeper_state)?;
-    emit_steward_stats(keeper_state)?;
+fn _process(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
+    emit_validator_history_metrics(keeper_state, cluster.clone())?;
+    emit_keeper_stats(keeper_state, cluster.clone())?;
+    emit_steward_stats(keeper_state, cluster.clone())?;
     Ok(())
 }
 
 pub fn fire(
     keeper_config: &KeeperConfig,
     keeper_state: &KeeperState,
+    cluster: String,
 ) -> (KeeperOperations, u64, u64, u64) {
     let operation = _get_operation();
     let (mut runs_for_epoch, mut errors_for_epoch, txs_for_epoch) =
@@ -41,7 +42,7 @@ pub fn fire(
     let should_run = _should_run() && check_flag(keeper_config.run_flags, operation);
 
     if should_run {
-        match _process(keeper_state) {
+        match _process(keeper_state, cluster) {
             Ok(_) => {
                 runs_for_epoch += 1;
             }
@@ -58,6 +59,7 @@ pub fn fire(
 // ----------------- OPERATION SPECIFIC FUNCTIONS -----------------
 pub fn emit_validator_history_metrics(
     keeper_state: &KeeperState,
+    cluster: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let epoch_info = &keeper_state.epoch_info;
     let get_vote_accounts = keeper_state.vote_account_map.values().collect::<Vec<_>>();
@@ -160,23 +162,25 @@ pub fn emit_validator_history_metrics(
             get_vote_accounts_voting,
             i64
         ),
+        ("cluster", cluster, String),
     );
 
     Ok(())
 }
 
-pub fn emit_keeper_stats(keeper_state: &KeeperState) -> Result<(), Box<dyn std::error::Error>> {
+pub fn emit_keeper_stats(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
     let keeper_balance = keeper_state.keeper_balance;
 
     datapoint_info!(
         "stakenet-keeper-stats",
         ("balance_lamports", keeper_balance, i64),
+        ("cluster", cluster, String),
     );
 
     Ok(())
 }
 
-pub fn emit_steward_stats(keeper_state: &KeeperState) -> Result<(), Box<dyn std::error::Error>> {
+pub fn emit_steward_stats(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
     //    - Progress
     // - Current State
     // - Num pool validators
@@ -331,6 +335,7 @@ pub fn emit_steward_stats(keeper_state: &KeeperState) -> Result<(), Box<dyn std:
             i64
         ),
         ("non_zero_score_count", non_zero_score_count, i64),
+        ("cluster", cluster, String),
     );
 
     let parameters = &keeper_state
@@ -411,7 +416,7 @@ pub fn emit_steward_stats(keeper_state: &KeeperState) -> Result<(), Box<dyn std:
             i64
         ),
         ("minimum_stake_lamports", minimum_stake_lamports, i64),
-        ("minimum_voting_epochs", minimum_voting_epochs, i64)
+        ("minimum_voting_epochs", minimum_voting_epochs, i64),
     );
 
     Ok(())

--- a/keepers/stakenet-keeper/src/operations/metrics_emit.rs
+++ b/keepers/stakenet-keeper/src/operations/metrics_emit.rs
@@ -162,7 +162,7 @@ pub fn emit_validator_history_metrics(
             get_vote_accounts_voting,
             i64
         ),
-        ("cluster", cluster, String),
+        "cluster" => cluster,
     );
 
     Ok(())
@@ -174,7 +174,7 @@ pub fn emit_keeper_stats(keeper_state: &KeeperState, cluster: String) -> Result<
     datapoint_info!(
         "stakenet-keeper-stats",
         ("balance_lamports", keeper_balance, i64),
-        ("cluster", cluster, String),
+        "cluster" => cluster,
     );
 
     Ok(())
@@ -335,7 +335,7 @@ pub fn emit_steward_stats(keeper_state: &KeeperState, cluster: String) -> Result
             i64
         ),
         ("non_zero_score_count", non_zero_score_count, i64),
-        ("cluster", cluster, String),
+        "cluster" => cluster,
     );
 
     let parameters = &keeper_state
@@ -417,7 +417,7 @@ pub fn emit_steward_stats(keeper_state: &KeeperState, cluster: String) -> Result
         ),
         ("minimum_stake_lamports", minimum_stake_lamports, i64),
         ("minimum_voting_epochs", minimum_voting_epochs, i64),
-        ("cluster", cluster, String),
+        "cluster" => cluster,
     );
 
     Ok(())

--- a/keepers/stakenet-keeper/src/operations/metrics_emit.rs
+++ b/keepers/stakenet-keeper/src/operations/metrics_emit.rs
@@ -23,17 +23,17 @@ fn _should_run() -> bool {
     true
 }
 
-fn _process(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
-    emit_validator_history_metrics(keeper_state, cluster.clone())?;
-    emit_keeper_stats(keeper_state, cluster.clone())?;
-    emit_steward_stats(keeper_state, cluster.clone())?;
+fn _process(keeper_state: &KeeperState, cluster: &str) -> Result<(), Box<dyn std::error::Error>> {
+    emit_validator_history_metrics(keeper_state, cluster)?;
+    emit_keeper_stats(keeper_state, cluster)?;
+    emit_steward_stats(keeper_state, cluster)?;
     Ok(())
 }
 
 pub fn fire(
     keeper_config: &KeeperConfig,
     keeper_state: &KeeperState,
-    cluster: String,
+    cluster: &str,
 ) -> (KeeperOperations, u64, u64, u64) {
     let operation = _get_operation();
     let (mut runs_for_epoch, mut errors_for_epoch, txs_for_epoch) =
@@ -59,7 +59,7 @@ pub fn fire(
 // ----------------- OPERATION SPECIFIC FUNCTIONS -----------------
 pub fn emit_validator_history_metrics(
     keeper_state: &KeeperState,
-    cluster: String,
+    cluster: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let epoch_info = &keeper_state.epoch_info;
     let get_vote_accounts = keeper_state.vote_account_map.values().collect::<Vec<_>>();
@@ -168,7 +168,10 @@ pub fn emit_validator_history_metrics(
     Ok(())
 }
 
-pub fn emit_keeper_stats(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
+pub fn emit_keeper_stats(
+    keeper_state: &KeeperState,
+    cluster: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     let keeper_balance = keeper_state.keeper_balance;
 
     datapoint_info!(
@@ -180,7 +183,10 @@ pub fn emit_keeper_stats(keeper_state: &KeeperState, cluster: String) -> Result<
     Ok(())
 }
 
-pub fn emit_steward_stats(keeper_state: &KeeperState, cluster: String) -> Result<(), Box<dyn std::error::Error>> {
+pub fn emit_steward_stats(
+    keeper_state: &KeeperState,
+    cluster: &str,
+) -> Result<(), Box<dyn std::error::Error>> {
     //    - Progress
     // - Current State
     // - Num pool validators

--- a/keepers/stakenet-keeper/src/state/keeper_config.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_config.rs
@@ -26,6 +26,7 @@ pub struct KeeperConfig {
     pub full_startup: bool,
     pub no_pack: bool,
     pub pay_for_new_accounts: bool,
+    pub cluster: Cluster,
 }
 
 #[derive(Parser, Debug)]

--- a/keepers/stakenet-keeper/src/state/keeper_config.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_config.rs
@@ -26,7 +26,7 @@ pub struct KeeperConfig {
     pub full_startup: bool,
     pub no_pack: bool,
     pub pay_for_new_accounts: bool,
-    pub cluster: Cluster,
+    pub cluster_name: String,
 }
 
 #[derive(Parser, Debug)]

--- a/keepers/stakenet-keeper/src/state/keeper_state.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_state.rs
@@ -115,7 +115,7 @@ pub struct KeeperState {
     pub all_steward_validator_accounts: Option<Box<AllValidatorAccounts>>,
     pub all_active_validator_accounts: Option<Box<AllValidatorAccounts>>,
     pub steward_progress_flags: StewardProgressFlags,
-    pub cluster: String,
+    pub cluster_name: String,
 }
 impl KeeperState {
     pub fn increment_update_run_for_epoch(&mut self, operation: KeeperOperations) {
@@ -283,8 +283,12 @@ impl KeeperState {
                 self.current_epoch_tip_distribution_map.len() as i64,
                 i64
             ),
-            ("cluster", self.cluster.as_str(), String),
+            ("cluster", &self.cluster_name, String),
         )
+    }
+
+    pub fn set_cluster_name(&mut self, cluster_name: &str) {
+        self.cluster_name = cluster_name.to_owned();
     }
 }
 
@@ -316,7 +320,7 @@ impl Default for KeeperState {
             all_steward_validator_accounts: None,
             all_active_validator_accounts: None,
             steward_progress_flags: StewardProgressFlags { flags: 0 },
-            cluster: String::from("mainnet"),
+            cluster_name: String::new(),
         }
     }
 }

--- a/keepers/stakenet-keeper/src/state/keeper_state.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_state.rs
@@ -115,6 +115,7 @@ pub struct KeeperState {
     pub all_steward_validator_accounts: Option<Box<AllValidatorAccounts>>,
     pub all_active_validator_accounts: Option<Box<AllValidatorAccounts>>,
     pub steward_progress_flags: StewardProgressFlags,
+    pub cluster: String,
 }
 impl KeeperState {
     pub fn increment_update_run_for_epoch(&mut self, operation: KeeperOperations) {
@@ -282,6 +283,7 @@ impl KeeperState {
                 self.current_epoch_tip_distribution_map.len() as i64,
                 i64
             ),
+            ("cluster", self.cluster.as_str(), String),
         )
     }
 }
@@ -314,6 +316,7 @@ impl Default for KeeperState {
             all_steward_validator_accounts: None,
             all_active_validator_accounts: None,
             steward_progress_flags: StewardProgressFlags { flags: 0 },
+            cluster: String::from("mainnet"),
         }
     }
 }


### PR DESCRIPTION
**Problem**
We would like to differentiate between keeper hosts running against different Solana network clusters but lack the ability to do so with our existing metrics setup.

**Solution**
- Wire thru `cluster_name` to `datapoint_info!` calls to be provided as a tag
- Add `REGION` env var to metrics only container 