### PR TITLE
fix: pin cargo-sort to compatible version

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -41,6 +41,7 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-sort
+          version: "1.0.9"
       - run: cargo +nightly-2024-02-04 sort --workspace --check
       - run: cargo +nightly-2024-02-04 fmt --all --check
       - run: cargo +nightly-2024-02-04 clippy --all-features --all-targets --tests -- -D warnings


### PR DESCRIPTION
**Problem**
CI fails because cargo-sort is not pinned to a version and the latest release of cargo-sort uses features that are unstable in our CI's version of rust.

**Solution**
- Pin cargo-sort to 1.0.9