### PR TITLE
feat: validator history priority fee support

### DIFF
--- a/programs/steward/src/score.rs
+++ b/programs/steward/src/score.rs
@@ -606,6 +606,9 @@ pub struct InstantUnstakeComponentsV3 {
     /// Checks if validator has an unacceptable merkle root upload authority
     pub is_bad_merkle_root_upload_authority: bool,
 
+    /// Checks if validator has an unacceptable priority fee merkle root upload authority
+    pub is_bad_priority_fee_merkle_root_upload_authority: bool,
+
     pub vote_account: Pubkey,
 
     pub epoch: u16,
@@ -716,6 +719,7 @@ pub fn instant_unstake_validator(
         mev_commission_check,
         is_blacklisted,
         is_bad_merkle_root_upload_authority,
+        is_bad_priority_fee_merkle_root_upload_authority,
         vote_account: validator.vote_account,
         epoch: current_epoch,
         details: InstantUnstakeDetails {

--- a/programs/steward/src/score.rs
+++ b/programs/steward/src/score.rs
@@ -459,6 +459,8 @@ pub fn calculate_blacklist(config: &Config, validator_index: u32) -> Result<f64>
 
 /// Checks if validator is using appropriate TDA MerkleRootUploadAuthority
 pub fn calculate_merkle_root_authority(validator: &ValidatorHistory) -> Result<f64> {
+    // calculate_instant_unstake_merkle_root_upload_auth returns whether or not
+    // instant unstake should be triggered, so we invert the result to get the score
     if calculate_instant_unstake_merkle_root_upload_auth(
         &validator.history.merkle_root_upload_authority_latest(),
     )? {

--- a/programs/validator-history/src/instructions/copy_priority_fee_distribution.rs
+++ b/programs/validator-history/src/instructions/copy_priority_fee_distribution.rs
@@ -4,7 +4,7 @@ use crate::{
     errors::ValidatorHistoryError,
     state::{Config, ValidatorHistory},
     utils::cast_epoch,
-    ValidatorHistoryEntry,
+    MerkleRootUploadAuthority, ValidatorHistoryEntry,
 };
 
 use jito_priority_fee_distribution::{
@@ -67,11 +67,13 @@ pub fn handle_copy_priority_fee_distribution_account(
     let distribution_account = PriorityFeeDistributionAccount::try_deserialize(&mut pdfa_data)?;
     let commission_bps = distribution_account.validator_commission_bps;
     let priority_fees_earned = distribution_account.total_lamports_transferred;
+    let merkle_root_upload_authority = distribution_account.merkle_root_upload_authority;
 
     validator_history_account.set_priority_fees_earned_and_commission(
         epoch,
         commission_bps,
         priority_fees_earned,
+        MerkleRootUploadAuthority::from_pubkey(&merkle_root_upload_authority),
     )?;
 
     Ok(())

--- a/programs/validator-history/src/instructions/copy_tip_distribution_account.rs
+++ b/programs/validator-history/src/instructions/copy_tip_distribution_account.rs
@@ -1,11 +1,10 @@
-use anchor_lang::{prelude::*, solana_program::vote};
-
 use crate::{
     errors::ValidatorHistoryError,
     state::{Config, ValidatorHistory},
     utils::{cast_epoch, fixed_point_sol},
     MerkleRootUploadAuthority, ValidatorHistoryEntry,
 };
+use anchor_lang::{prelude::*, solana_program::vote};
 
 use jito_tip_distribution::state::TipDistributionAccount;
 

--- a/programs/validator-history/src/instructions/update_priority_fee_history.rs
+++ b/programs/validator-history/src/instructions/update_priority_fee_history.rs
@@ -34,7 +34,7 @@ pub fn handle_update_priority_fee_history(
     total_priority_fees: u64,
     total_leader_slots: u32,
     blocks_produced: u32,
-    current_slot: u64, //TODO Take out
+    current_slot: u64,
 ) -> Result<()> {
     let mut validator_history_account = ctx.accounts.validator_history_account.load_mut()?;
     let clock = Clock::get()?;

--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -75,10 +75,11 @@ static_assertions::const_assert_eq!(size_of::<ValidatorHistoryEntry>(), 128);
 #[repr(u8)]
 pub enum MerkleRootUploadAuthority {
     #[default]
-    Empty,
-    Other,
-    OldJitoLabs,
-    TipRouter,
+    Unset = 0,
+    Empty = u8::MAX,
+    Other = 1,
+    OldJitoLabs = 2,
+    TipRouter = 3,
 }
 
 unsafe impl Zeroable for MerkleRootUploadAuthority {}
@@ -103,6 +104,10 @@ impl IdlBuild for MerkleRootUploadAuthority {
             name: "MerkleRootUploadAuthority".to_string(),
             ty: IdlTypeDefTy::Enum {
                 variants: vec![
+                    IdlEnumVariant {
+                        name: "Unset".to_string(),
+                        fields: None,
+                    },
                     IdlEnumVariant {
                         name: "Empty".to_string(),
                         fields: None,
@@ -167,7 +172,9 @@ pub struct ValidatorHistoryEntry {
     pub blocks_produced: u32,
     // The last slot the block data was last updated at
     pub block_data_updated_at_slot: u64,
-    pub padding1: [u8; 48],
+    /// The enum mapping of the Validator's Tip Distribution Account's merkle root upload authority
+    pub priority_fee_merkle_root_upload_authority: MerkleRootUploadAuthority,
+    pub padding1: [u8; 47],
 }
 
 // Default values for fields in `ValidatorHistoryEntry` are the type's max value.
@@ -191,7 +198,7 @@ impl Default for ValidatorHistoryEntry {
             rank: u32::MAX,
             vote_account_last_update_slot: u64::MAX,
             mev_earned: u32::MAX,
-            merkle_root_upload_authority: MerkleRootUploadAuthority::default(),
+            merkle_root_upload_authority: MerkleRootUploadAuthority::Unset,
             priority_fee_tips: u64::MAX,
             total_priority_fees: u64::MAX,
             priority_fee_commission: u16::MAX,
@@ -199,12 +206,13 @@ impl Default for ValidatorHistoryEntry {
             blocks_produced: u32::MAX,
             padding0: [u8::MAX, 2],
             block_data_updated_at_slot: u64::MAX,
-            padding1: [u8::MAX; 48],
+            priority_fee_merkle_root_upload_authority: MerkleRootUploadAuthority::Unset,
+            padding1: [u8::MAX; 47],
         }
     }
 }
 
-#[derive(BorshSerialize, BorshDeserialize)]
+#[derive(BorshSerialize, BorshDeserialize, PartialEq)]
 #[zero_copy]
 pub struct ClientVersion {
     pub major: u8,
@@ -389,6 +397,10 @@ impl CircBuf {
         field_latest!(self, merkle_root_upload_authority)
     }
 
+    pub fn priority_fee_merkle_root_upload_authority_latest(&self) -> Option<MerkleRootUploadAuthority> {
+        field_latest!(self, priority_fee_merkle_root_upload_authority)
+    }
+
     pub fn priority_fee_tips_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u64>> {
         field_range!(self, start_epoch, end_epoch, priority_fee_tips, u64)
     }
@@ -396,6 +408,57 @@ impl CircBuf {
     pub fn total_priority_fees_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u64>> {
         field_range!(self, start_epoch, end_epoch, total_priority_fees, u64)
     }
+
+    pub fn priority_fee_tips_latest(&self) -> Option<u64> {
+        field_latest!(self, priority_fee_tips)
+    }
+
+    pub fn total_priority_fees_latest(&self) -> Option<u64> {
+        field_latest!(self, total_priority_fees)
+    }
+
+    pub fn merkle_root_upload_authority_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<MerkleRootUploadAuthority>> {
+        field_range!(
+            self,
+            start_epoch,
+            end_epoch,
+            merkle_root_upload_authority,
+            MerkleRootUploadAuthority
+        )
+    }
+
+    pub fn priority_fee_merkle_root_upload_authority_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<MerkleRootUploadAuthority>> {
+        field_range!(
+            self,
+            start_epoch,
+            end_epoch,
+            priority_fee_merkle_root_upload_authority,
+            MerkleRootUploadAuthority
+        )
+    }
+
+    pub fn vote_account_last_update_slot_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<u64>> {
+        field_range!(
+            self,
+            start_epoch,
+            end_epoch,
+            vote_account_last_update_slot,
+            u64
+        )
+    }
+
     /// Normalized epoch credits, accounting for Timely Vote Credits making the max number of credits 16x higher
     /// for every epoch starting at `tvc_activation_epoch`
     pub fn epoch_credits_latest_normalized(
@@ -466,6 +529,104 @@ impl CircBuf {
 
     pub fn vote_account_last_update_slot_latest(&self) -> Option<u64> {
         field_latest!(self, vote_account_last_update_slot)
+    }
+
+    pub fn activated_stake_lamports_latest(&self) -> Option<u64> {
+        field_latest!(self, activated_stake_lamports)
+    }
+
+    pub fn activated_stake_lamports_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<u64>> {
+        field_range!(self, start_epoch, end_epoch, activated_stake_lamports, u64)
+    }
+
+    pub fn client_type_latest(&self) -> Option<u8> {
+        field_latest!(self, client_type)
+    }
+
+    pub fn client_type_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u8>> {
+        field_range!(self, start_epoch, end_epoch, client_type, u8)
+    }
+
+    pub fn version_latest(&self) -> Option<ClientVersion> {
+        field_latest!(self, version)
+    }
+
+    pub fn version_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<ClientVersion>> {
+        field_range!(self, start_epoch, end_epoch, version, ClientVersion)
+    }
+
+    pub fn ip_latest(&self) -> Option<[u8; 4]> {
+        field_latest!(self, ip)
+    }
+
+    pub fn ip_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<[u8; 4]>> {
+        field_range!(self, start_epoch, end_epoch, ip, [u8; 4])
+    }
+
+    pub fn rank_latest(&self) -> Option<u32> {
+        field_latest!(self, rank)
+    }
+
+    pub fn rank_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u32>> {
+        field_range!(self, start_epoch, end_epoch, rank, u32)
+    }
+
+    pub fn mev_earned_latest(&self) -> Option<u32> {
+        field_latest!(self, mev_earned)
+    }
+
+    pub fn mev_earned_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u32>> {
+        field_range!(self, start_epoch, end_epoch, mev_earned, u32)
+    }
+
+    pub fn priority_fee_commission_latest(&self) -> Option<u16> {
+        field_latest!(self, priority_fee_commission)
+    }
+
+    pub fn priority_fee_commission_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<u16>> {
+        field_range!(self, start_epoch, end_epoch, priority_fee_commission, u16)
+    }
+
+    pub fn total_leader_slots_latest(&self) -> Option<u32> {
+        field_latest!(self, total_leader_slots)
+    }
+
+    pub fn total_leader_slots_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u32>> {
+        field_range!(self, start_epoch, end_epoch, total_leader_slots, u32)
+    }
+
+    pub fn blocks_produced_latest(&self) -> Option<u32> {
+        field_latest!(self, blocks_produced)
+    }
+
+    pub fn blocks_produced_range(&self, start_epoch: u16, end_epoch: u16) -> Vec<Option<u32>> {
+        field_range!(self, start_epoch, end_epoch, blocks_produced, u32)
+    }
+
+    pub fn block_data_updated_at_slot_latest(&self) -> Option<u64> {
+        field_latest!(self, block_data_updated_at_slot)
+    }
+
+    pub fn block_data_updated_at_slot_range(
+        &self,
+        start_epoch: u16,
+        end_epoch: u16,
+    ) -> Vec<Option<u64>> {
+        field_range!(
+            self,
+            start_epoch,
+            end_epoch,
+            block_data_updated_at_slot,
+            u64
+        )
     }
 }
 
@@ -552,12 +713,14 @@ impl ValidatorHistory {
         epoch: u16,
         commission: u16,
         priority_fee_tips: u64,
+        merkle_root_upload_authority: MerkleRootUploadAuthority,
     ) -> Result<()> {
         if let Some(entry) = self.history.last_mut() {
             match entry.epoch.cmp(&epoch) {
                 Ordering::Equal => {
                     entry.priority_fee_commission = commission;
                     entry.priority_fee_tips = priority_fee_tips;
+                    entry.priority_fee_merkle_root_upload_authority = merkle_root_upload_authority;
                     return Ok(());
                 }
                 Ordering::Greater => {
@@ -569,6 +732,8 @@ impl ValidatorHistory {
                     {
                         entry.priority_fee_commission = commission;
                         entry.priority_fee_tips = priority_fee_tips;
+                        entry.priority_fee_merkle_root_upload_authority =
+                            merkle_root_upload_authority;
                     }
                     return Ok(());
                 }
@@ -579,6 +744,7 @@ impl ValidatorHistory {
             epoch,
             priority_fee_commission: commission,
             priority_fee_tips,
+            merkle_root_upload_authority,
             ..ValidatorHistoryEntry::default()
         };
         self.history.push(entry);

--- a/programs/validator-history/src/state.rs
+++ b/programs/validator-history/src/state.rs
@@ -75,8 +75,7 @@ static_assertions::const_assert_eq!(size_of::<ValidatorHistoryEntry>(), 128);
 #[repr(u8)]
 pub enum MerkleRootUploadAuthority {
     #[default]
-    Unset = 0,
-    Empty = u8::MAX,
+    Unset = u8::MAX,
     Other = 1,
     OldJitoLabs = 2,
     TipRouter = 3,
@@ -397,7 +396,9 @@ impl CircBuf {
         field_latest!(self, merkle_root_upload_authority)
     }
 
-    pub fn priority_fee_merkle_root_upload_authority_latest(&self) -> Option<MerkleRootUploadAuthority> {
+    pub fn priority_fee_merkle_root_upload_authority_latest(
+        &self,
+    ) -> Option<MerkleRootUploadAuthority> {
         field_latest!(self, priority_fee_merkle_root_upload_authority)
     }
 

--- a/tests/tests/steward/test_algorithms.rs
+++ b/tests/tests/steward/test_algorithms.rs
@@ -65,6 +65,7 @@ fn test_compute_score() {
             priority_fee_commission_score: 1.0,
             vote_account: good_validator.vote_account,
             epoch: current_epoch as u16,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             details: ScoreDetails {
                 max_mev_commission: 0,
                 max_mev_commission_epoch: 10,
@@ -107,6 +108,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -150,6 +152,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -193,6 +196,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -240,6 +244,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -285,6 +290,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -331,6 +337,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -378,6 +385,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -422,6 +430,7 @@ fn test_compute_score() {
             commission_score: 0.0,
             historical_commission_score: 0.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -474,6 +483,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -516,6 +526,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 0.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -565,6 +576,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -609,6 +621,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -658,6 +671,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -705,6 +719,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -789,6 +804,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 0.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -837,6 +853,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -885,6 +902,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -935,6 +953,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 1.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -985,6 +1004,7 @@ fn test_compute_score() {
             commission_score: 1.0,
             historical_commission_score: 1.0,
             merkle_root_upload_authority_score: 1.0,
+            priority_fee_merkle_root_upload_authority_score: 1.0,
             priority_fee_commission_score: 0.0,
             vote_account: validator.vote_account,
             epoch: current_epoch as u16,
@@ -1052,6 +1072,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: good_validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1089,6 +1110,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: true,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: good_validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1123,6 +1145,7 @@ fn test_instant_unstake() {
             mev_commission_check: true,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: bad_validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1175,6 +1198,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1227,6 +1251,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1261,6 +1286,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1295,6 +1321,7 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
             vote_account: good_validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {
@@ -1333,6 +1360,45 @@ fn test_instant_unstake() {
             mev_commission_check: false,
             is_blacklisted: false,
             is_bad_merkle_root_upload_authority: true,
+            is_bad_priority_fee_merkle_root_upload_authority: false,
+            vote_account: validator.vote_account,
+            epoch: current_epoch,
+            details: InstantUnstakeDetails {
+                epoch_credits_latest: 1000 * (TVC_MULTIPLIER as u64),
+                vote_account_last_update_slot: end_slot,
+                total_blocks_latest: 0,
+                cluster_history_slot_index: slot_index,
+                commission: 0,
+                mev_commission: 0
+            }
+        }
+    );
+
+    let mut validator = validators[0];
+    validator
+        .history
+        .last_mut()
+        .unwrap()
+        .priority_fee_merkle_root_upload_authority = MerkleRootUploadAuthority::Other;
+    let res = instant_unstake_validator(
+        &validator,
+        &cluster_history,
+        &config,
+        start_slot,
+        current_epoch,
+        TVC_ACTIVATION_EPOCH,
+    );
+    assert!(res.is_ok());
+    assert_eq!(
+        res.unwrap(),
+        InstantUnstakeComponentsV3 {
+            instant_unstake: true,
+            delinquency_check: false,
+            commission_check: false,
+            mev_commission_check: false,
+            is_blacklisted: false,
+            is_bad_merkle_root_upload_authority: false,
+            is_bad_priority_fee_merkle_root_upload_authority: true,
             vote_account: validator.vote_account,
             epoch: current_epoch,
             details: InstantUnstakeDetails {

--- a/tests/tests/steward/test_scoring.rs
+++ b/tests/tests/steward/test_scoring.rs
@@ -1005,8 +1005,10 @@ mod test_calculate_instant_unstake_merkle_root_upload_auth {
             merkle_root_upload_authority: MerkleRootUploadAuthority::Other,
             ..Default::default()
         });
-        let is_instant_unstake =
-            calculate_instant_unstake_merkle_root_upload_auth(&validator).unwrap();
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator.history.merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
         assert!(is_instant_unstake);
 
         // MerkleRootUploadAuthority::OldJitoLabs should never instant unstake
@@ -1014,16 +1016,58 @@ mod test_calculate_instant_unstake_merkle_root_upload_auth {
             merkle_root_upload_authority: MerkleRootUploadAuthority::OldJitoLabs,
             ..Default::default()
         });
-        let is_instant_unstake =
-            calculate_instant_unstake_merkle_root_upload_auth(&validator).unwrap();
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator.history.merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
         assert!(!is_instant_unstake);
         // MerkleRootUploadAuthority::TipRouter should never instant unstake
         validator.history.push(ValidatorHistoryEntry {
             merkle_root_upload_authority: MerkleRootUploadAuthority::TipRouter,
             ..Default::default()
         });
-        let is_instant_unstake =
-            calculate_instant_unstake_merkle_root_upload_auth(&validator).unwrap();
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator.history.merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
+        assert!(!is_instant_unstake);
+
+        // Priority fees: When using MerkleRootUploadAuthority::Other should always instant unstake
+        validator.history.push(ValidatorHistoryEntry {
+            priority_fee_merkle_root_upload_authority: MerkleRootUploadAuthority::Other,
+            ..Default::default()
+        });
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator
+                .history
+                .priority_fee_merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
+        assert!(is_instant_unstake);
+
+        // Priorty fees: MerkleRootUploadAuthority::OldJitoLabs should never instant unstake
+        validator.history.push(ValidatorHistoryEntry {
+            priority_fee_merkle_root_upload_authority: MerkleRootUploadAuthority::OldJitoLabs,
+            ..Default::default()
+        });
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator
+                .history
+                .priority_fee_merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
+        assert!(!is_instant_unstake);
+        // Priority fees: MerkleRootUploadAuthority::TipRouter should never instant unstake
+        validator.history.push(ValidatorHistoryEntry {
+            priority_fee_merkle_root_upload_authority: MerkleRootUploadAuthority::TipRouter,
+            ..Default::default()
+        });
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator
+                .history
+                .priority_fee_merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
         assert!(!is_instant_unstake);
     }
 
@@ -1031,8 +1075,10 @@ mod test_calculate_instant_unstake_merkle_root_upload_auth {
     fn test_edge_cases() {
         // Empty history
         let validator = create_validator_history(&[], &[], &[], &[], &[], &[]);
-        let is_instant_unstake =
-            calculate_instant_unstake_merkle_root_upload_auth(&validator).unwrap();
+        let is_instant_unstake = calculate_instant_unstake_merkle_root_upload_auth(
+            &validator.history.merkle_root_upload_authority_latest(),
+        )
+        .unwrap();
         assert!(!is_instant_unstake);
     }
 }


### PR DESCRIPTION
```
test steward::test_cycle::test_cycle ... ok

test result: ok. 126 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.34s

   Doc-tests tests

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```