### PR TITLE
feat: use priority fee merkle root upload authority as scoring component

### DIFF
--- a/programs/steward/src/score.rs
+++ b/programs/steward/src/score.rs
@@ -180,7 +180,7 @@ pub fn validator_score(
 
     let merkle_root_upload_authority_score = calculate_merkle_root_authority_score(validator)?;
     let priority_fee_merkle_root_upload_authority_score =
-        calculate_priority_fee_merkle_root_authority(validator)?;
+        calculate_priority_fee_merkle_root_authority_score(validator)?;
 
     let (
         priority_fee_commission_score,
@@ -201,7 +201,8 @@ pub fn validator_score(
         * running_jito_score
         * yield_score
         * merkle_root_upload_authority_score
-        * priority_fee_commission_score;
+        * priority_fee_commission_score
+        * priority_fee_merkle_root_upload_authority_score;
 
     Ok(ScoreComponentsV3 {
         score,
@@ -472,7 +473,9 @@ pub fn calculate_merkle_root_authority_score(validator: &ValidatorHistory) -> Re
 }
 
 /// Checks if validator is using appropriate TDA MerkleRootUploadAuthority
-pub fn calculate_priority_fee_merkle_root_authority(validator: &ValidatorHistory) -> Result<f64> {
+pub fn calculate_priority_fee_merkle_root_authority_score(
+    validator: &ValidatorHistory,
+) -> Result<f64> {
     if calculate_instant_unstake_merkle_root_upload_auth(
         &validator
             .history
@@ -820,6 +823,9 @@ pub fn calculate_instant_unstake_merkle_root_upload_auth(
 ) -> Result<bool> {
     if let Some(merkle_root_upload_authority) = latest_authority {
         match merkle_root_upload_authority {
+            // Although the statement above will cover Unset, we want to be explicit about it
+            // and safegaurd against any future changes to the latest_authority that gets passed in
+            MerkleRootUploadAuthority::Unset => Ok(false),
             MerkleRootUploadAuthority::OldJitoLabs => Ok(false),
             MerkleRootUploadAuthority::TipRouter => Ok(false),
             _ => Ok(true),

--- a/tests/tests/steward/test_scoring.rs
+++ b/tests/tests/steward/test_scoring.rs
@@ -591,6 +591,94 @@ mod test_calculate_realized_commission_bps {
     }
 }
 
+mod test_calculate_priority_fee_merkle_root_upload_authority {
+    use super::*;
+
+    // calculate_priority_fee_merkle_root_authority_score looks exclusively at the latest authority
+    // so we can test with a single epoch
+    #[test]
+    fn test_normal() {
+        let validator = create_validator_history(
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[MerkleRootUploadAuthority::TipRouter; 1],
+        );
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 1.0);
+    }
+
+    #[test]
+    fn test_no_data() {
+        let validator = create_validator_history(&[], &[], &[], &[], &[], &[], &[]);
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 1.0);
+    }
+
+    #[test]
+    fn test_unset() {
+        let validator = create_validator_history(
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[MerkleRootUploadAuthority::Unset; 1],
+        );
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 1.0);
+    }
+
+    #[test]
+    fn test_old_jito_labs() {
+        let validator = create_validator_history(
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[MerkleRootUploadAuthority::OldJitoLabs; 1],
+        );
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 1.0);
+    }
+
+    #[test]
+    fn test_other() {
+        let validator = create_validator_history(
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[MerkleRootUploadAuthority::Other; 1],
+        );
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 0.0);
+    }
+
+    #[test]
+    fn test_dne() {
+        let validator = create_validator_history(
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[0; 1],
+            &[MerkleRootUploadAuthority::DNE; 1],
+        );
+        let score = calculate_priority_fee_merkle_root_authority_score(&validator).unwrap();
+        assert_eq!(score, 0.0);
+    }
+}
+
 mod test_calculate_priority_fee_commission {
     use jito_steward::constants::{BASIS_POINTS_MAX, EPOCH_DEFAULT};
 


### PR DESCRIPTION
**Problem**

The priority fee merkle root upload authority is not yet a component of the score despite appearing to be in the unstake and scoring details.

**Solution**
- Include priority fee merkle root upload authority as a component of scoring
- Ensure that an Unset authority results in a score of 1.0 to default to not penalizing the validator in this scenario