### PR TITLE
steward-cli: view priority fee config and optional print gov ix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10725,6 +10725,7 @@ version = "0.1.0"
 dependencies = [
  "anchor-lang",
  "anyhow",
+ "base64 0.22.1",
  "borsh 1.5.7",
  "clap 4.5.42",
  "dotenvy",

--- a/utils/steward-cli/Cargo.toml
+++ b/utils/steward-cli/Cargo.toml
@@ -7,7 +7,8 @@ description = "CLI to manage the steward program"
 [dependencies]
 anchor-lang = "0.31.1"
 anyhow = "1.0.86"
-borsh = { version = "1.5.7" }
+base64 = "0.22.1"
+borsh = "1.5.7"
 clap = { version = "4.3.0", features = ["derive", "env"] }
 dotenvy = { workspace = true }
 futures = "0.3.21"

--- a/utils/steward-cli/src/commands/command_args.rs
+++ b/utils/steward-cli/src/commands/command_args.rs
@@ -240,6 +240,7 @@ pub enum Commands {
     // Views
     ViewState(ViewState),
     ViewConfig(ViewConfig),
+    ViewPriorityFeeConfig(ViewPriorityFeeConfig),
     ViewNextIndexToRemove(ViewNextIndexToRemove),
 
     // Actions
@@ -300,6 +301,13 @@ pub struct ViewState {
 #[derive(Parser)]
 #[command(about = "View the current steward config account")]
 pub struct ViewConfig {
+    #[command(flatten)]
+    pub view_parameters: ViewParameters,
+}
+
+#[derive(Parser)]
+#[command(about = "View the current steward priority fee config parameters")]
+pub struct ViewPriorityFeeConfig {
     #[command(flatten)]
     pub view_parameters: ViewParameters,
 }
@@ -367,6 +375,13 @@ pub enum AuthoritySubcommand {
     },
     /// Manages parameters authority
     Parameters {
+        #[command(flatten)]
+        permissioned_parameters: PermissionedParameters,
+        #[arg(long, env)]
+        new_authority: Pubkey,
+    },
+    /// Manages priority fee parameters authority
+    PriorityFeeParameters {
         #[command(flatten)]
         permissioned_parameters: PermissionedParameters,
         #[arg(long, env)]

--- a/utils/steward-cli/src/commands/info/mod.rs
+++ b/utils/steward-cli/src/commands/info/mod.rs
@@ -1,3 +1,4 @@
 pub mod view_config;
 pub mod view_next_index_to_remove;
+pub mod view_priority_fee_config;
 pub mod view_state;

--- a/utils/steward-cli/src/commands/info/view_priority_fee_config.rs
+++ b/utils/steward-cli/src/commands/info/view_priority_fee_config.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use jito_steward::Config;
+use solana_client::nonblocking::rpc_client::RpcClient;
+
+use solana_sdk::pubkey::Pubkey;
+
+use crate::commands::command_args::ViewPriorityFeeConfig;
+use stakenet_sdk::utils::accounts::get_all_steward_accounts;
+
+pub async fn command_view_priority_fee_config(
+    args: ViewPriorityFeeConfig,
+    client: &Arc<RpcClient>,
+    program_id: Pubkey,
+) -> Result<()> {
+    let steward_config = args.view_parameters.steward_config;
+
+    let all_steward_accounts =
+        get_all_steward_accounts(client, &program_id, &steward_config).await?;
+
+    print_priority_fee_config(
+        &all_steward_accounts.config_address,
+        &all_steward_accounts.config_account,
+    );
+
+    Ok(())
+}
+
+fn print_priority_fee_config(steward_config: &Pubkey, config_account: &Config) {
+    let mut formatted_string = String::new();
+
+    formatted_string += "------- Priority Fee Config -------\n";
+    formatted_string += "📚 Accounts 📚\n";
+    formatted_string += &format!("Config:      {}\n", steward_config);
+    formatted_string += &format!(
+        "Priority Fee Parameters Authority:   {}\n",
+        config_account.priority_fee_parameters_authority
+    );
+    formatted_string += "\n⚙️ Priority Fee Parameters ⚙️\n";
+    formatted_string += &format!(
+        "Priority Fee Lookback Epochs:  {:?}\n",
+        config_account.parameters.priority_fee_lookback_epochs
+    );
+    formatted_string += &format!(
+        "Priority Fee Lookback Offset:  {:?}\n",
+        config_account.parameters.priority_fee_lookback_offset
+    );
+    formatted_string += &format!(
+        "Priority Fee Max Commission BPS:  {:?}\n",
+        config_account.parameters.priority_fee_max_commission_bps
+    );
+    formatted_string += &format!(
+        "Priority Fee Error Margin BPS:  {:?}\n",
+        config_account.parameters.priority_fee_error_margin_bps
+    );
+    formatted_string += &format!(
+        "Priority Fee Scoring Start Epoch:  {:?}\n",
+        config_account.parameters.priority_fee_scoring_start_epoch
+    );
+    formatted_string += "--------------------------------\n";
+
+    println!("{}", formatted_string);
+}

--- a/utils/steward-cli/src/main.rs
+++ b/utils/steward-cli/src/main.rs
@@ -32,7 +32,7 @@ use commands::{
     info::{
         view_config::command_view_config,
         view_next_index_to_remove::command_view_next_index_to_remove,
-        view_state::command_view_state,
+        view_priority_fee_config::command_view_priority_fee_config, view_state::command_view_state,
     },
     init::{init_steward::command_init_steward, realloc_state::command_realloc_state},
 };
@@ -55,6 +55,9 @@ async fn main() -> Result<()> {
     let result = match args.commands {
         // ---- Views ----
         Commands::ViewConfig(args) => command_view_config(args, &client, program_id).await,
+        Commands::ViewPriorityFeeConfig(args) => {
+            command_view_priority_fee_config(args, &client, program_id).await
+        }
         Commands::ViewState(args) => command_view_state(args, &client, program_id).await,
         Commands::ViewNextIndexToRemove(args) => {
             command_view_next_index_to_remove(args, &client, program_id).await


### PR DESCRIPTION
**Problem**
We would like base64 encoded instructions in the same format as spl_governance, but spl_governance does not have a compatible release with solana 2.x deps.

**Solution**
- Use source code from spl_governance in steward cli utils