### PR TITLE
Docker: Fix build error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 RUN --mount=type=cache,mode=0777,target=/home/root/app/target \
     --mount=type=cache,mode=0777,target=/usr/local/cargo/registry \
-	cargo build --release --bin stakenet-keeper
+	cargo build --release --features idl-build --bin stakenet-keeper
 
 #########
 


### PR DESCRIPTION
https://github.com/jito-foundation/stakenet/actions/runs/19281779659
```
buildx failed with: ERROR: failed to build: failed to solve: process "/bin/sh -c cargo build --release --bin stakenet-keeper" did not complete successfully: exit code: 101
```