### PR TITLE
CLI: Compute directed stake meta

### DIFF
--- a/utils/steward-cli/src/commands/cranks/compute_directed_stake_meta.rs
+++ b/utils/steward-cli/src/commands/cranks/compute_directed_stake_meta.rs
@@ -228,7 +228,8 @@ pub async fn command_crank_compute_directed_stake_meta(
         get_directed_stake_meta(client.clone(), &steward_config, &program_id).await?;
 
     println!("\nValidator Targets:");
-    for target in directed_stake_meta.targets {
+    for i in 0..directed_stake_meta.total_stake_targets as usize {
+        let target = &directed_stake_meta.targets[i];
         if target.vote_pubkey != Pubkey::default() {
             println!("  Vote Pubkey: {}", target.vote_pubkey);
             println!(


### PR DESCRIPTION
- Enable to output the list of vote account and target lamports

```bash
=== Directed Stake Metadata Computation Summary ===
Total Directed Stake Tickets: 1
Tickets with JitoSOL Balance: 1
Total Stake Preferences: 1
Unique Validators in Tickets: 1
Final Aggregated Targets: 1 (after filtering by balance)
====================================================


=== Transaction Successful ===
Signature: r9TUEYGnzPqZZjiZ8pnHYeFuLdqAYRLYwYe2vm9LEnDYsmhnKQcXs86NdeLatVwUWwnET1JBBSTqMWivkGVT9GK
Updated metadata:
  - 1 tickets processed
  - 1 tickets with balance
  - 1 final validator targets

Validator Targets:
  Vote Pubkey: J1to2NAwajc8hD6E6kujdQiPn1Bbt2mGKKZLY9kSQKdB
    Target: 0 lamports (0.00 SOL)
  Vote Pubkey: CbTyjrnyweSYGw65nrG3oPmApUK2MYAq7xyveTxg4zMz
    Target: 0 lamports (0.00 SOL)
  Vote Pubkey: FWxdBnWZ13m3CqNuKBH2KQWkF6EFF1Utja5Cy7iqG2nE
    Target: 9420818840 lamports (9.42 SOL)
```