### PR TITLE
`nit`: remove modulus

### DIFF
--- a/programs/validator-history/src/utils.rs
+++ b/programs/validator-history/src/utils.rs
@@ -11,8 +11,7 @@ pub fn cast_epoch(epoch: u64) -> Result<u16> {
         epoch < (u16::MAX as u64),
         ValidatorHistoryError::EpochTooLarge
     );
-    let epoch_u16: u16 = (epoch % u16::MAX as u64).try_into().unwrap();
-    Ok(epoch_u16)
+    Ok(epoch as u16)
 }
 
 pub fn get_min_epoch(


### PR DESCRIPTION
The `require!` check makes the modulus not necessary