### PR TITLE
Remove from blacklist with squads

### DIFF
--- a/utils/steward-cli/src/commands/actions/remove_from_blacklist.rs
+++ b/utils/steward-cli/src/commands/actions/remove_from_blacklist.rs
@@ -1,70 +1,214 @@
 use std::sync::Arc;
 
-use anchor_lang::{InstructionData, ToAccountMetas};
+use crate::cli_signer::CliSigner;
+use anchor_lang::{AccountDeserialize, InstructionData, ToAccountMetas};
 use anyhow::Result;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::instruction::Instruction;
-
-use solana_sdk::{
-    pubkey::Pubkey, signature::read_keypair_file, signer::Signer, transaction::Transaction,
+use squads_multisig::client::{
+    get_multisig, proposal_create, vault_transaction_create, ProposalCreateAccounts,
+    ProposalCreateArgs, VaultTransactionCreateAccounts,
 };
+use squads_multisig::pda::{get_proposal_pda, get_transaction_pda, get_vault_pda};
+use squads_multisig::state::TransactionMessage;
+use squads_multisig::vault_transaction::VaultTransactionMessageExt;
+
+use crate::utils::transactions::{configure_instruction, maybe_print_tx};
+#[allow(deprecated)]
+use solana_sdk::{pubkey::Pubkey, signer::Signer, system_program, transaction::Transaction};
 
 use crate::commands::command_args::RemoveFromBlacklist;
-use crate::utils::transactions::{configure_instruction, maybe_print_tx};
+use stakenet_sdk::utils::accounts::get_validator_history_address;
+use validator_history::{self, ValidatorHistory};
 
 pub async fn command_remove_from_blacklist(
     args: RemoveFromBlacklist,
     client: &Arc<RpcClient>,
     program_id: Pubkey,
+    cli_signer: &CliSigner,
 ) -> Result<()> {
-    // Creates config account
-    let authority = read_keypair_file(args.permissioned_parameters.authority_keypair_path)
-        .expect("Failed reading keypair file ( Authority )");
+    // Fetch config account for blacklist authority
+    let config_account = client
+        .get_account(&args.permissioned_parameters.steward_config)
+        .await?;
+    let config = jito_steward::Config::try_deserialize(&mut config_account.data.as_slice())?;
+    let blacklist_authority = config.blacklist_authority;
 
-    let ix = Instruction {
+    // Build list of indices, starting with those passed directly
+    let mut indices = args.validator_history_indices_to_deblacklist.clone();
+    // Fetch indices for each vote account provided
+    println!("Vote Account\tHistory Address\tIndex");
+    for vote_account in args.vote_accounts_to_deblacklist.iter() {
+        let history_address = get_validator_history_address(vote_account, &validator_history::id());
+        let (vh_index, account_exists) = match client.get_account(&history_address).await {
+            Ok(account) => match ValidatorHistory::try_deserialize(&mut account.data.as_slice()) {
+                Ok(vh) => (vh.index.to_string(), true),
+                Err(_) => ("N/A".to_string(), false),
+            },
+            Err(_) => ("N/A".to_string(), false),
+        };
+        println!(
+            "{}\thttps://solscan.io/account/{}\t{}",
+            vote_account, history_address, vh_index
+        );
+        if account_exists {
+            indices.push(vh_index.parse()?);
+        }
+    }
+
+    let deblacklist_ix = Instruction {
         program_id,
         accounts: jito_steward::accounts::RemoveValidatorsFromBlacklist {
             config: args.permissioned_parameters.steward_config,
-            authority: authority.pubkey(),
+            authority: blacklist_authority,
         }
         .to_account_metas(None),
         data: jito_steward::instruction::RemoveValidatorsFromBlacklist {
-            validator_history_blacklist: args.validator_history_indices_to_deblacklist,
+            validator_history_blacklist: indices,
         }
         .data(),
     };
 
-    let blockhash = client.get_latest_blockhash().await?;
+    // If Squads proposal flag is set, create a Squads proposal
+    if args.squads_proposal {
+        let multisig = args.squads_multisig;
+        let squads_program_id = args
+            .squads_program_id
+            .unwrap_or(squads_multisig::squads_multisig_program::ID);
 
-    let configured_ix = configure_instruction(
-        &[ix],
-        args.permissioned_parameters
-            .transaction_parameters
-            .priority_fee,
-        args.permissioned_parameters
-            .transaction_parameters
-            .compute_limit,
-        args.permissioned_parameters
-            .transaction_parameters
-            .heap_size,
-    );
+        println!("  Multisig Address: {}", multisig);
+        println!("  Squads Program ID: {}", squads_program_id);
 
-    let transaction = Transaction::new_signed_with_payer(
-        &configured_ix,
-        Some(&authority.pubkey()),
-        &[&authority],
-        blockhash,
-    );
+        // Fetch the multisig account to get the transaction index
+        println!("  Fetching multisig account...");
+        let multisig_account = get_multisig(client, &multisig).await.map_err(|e| {
+            eprintln!("❌ Failed to fetch multisig account: {}", e);
+            e
+        })?;
+        let transaction_index = multisig_account.transaction_index + 1;
+        println!("  Next transaction index: {}", transaction_index);
 
-    if !maybe_print_tx(
-        &configured_ix,
-        &args.permissioned_parameters.transaction_parameters,
-    ) {
-        let signature = client
-            .send_and_confirm_transaction_with_spinner(&transaction)
-            .await?;
+        // Derive PDAs
+        let vault_pda =
+            get_vault_pda(&multisig, args.squads_vault_index, Some(&squads_program_id)).0;
+        let transaction_pda =
+            get_transaction_pda(&multisig, transaction_index, Some(&squads_program_id)).0;
+        let proposal_pda =
+            get_proposal_pda(&multisig, transaction_index, Some(&squads_program_id)).0;
 
-        println!("Signature: {}", signature);
+        // Assert vault PDA is blacklist authority
+        if vault_pda != blacklist_authority {
+            return Err(anyhow::anyhow!(
+                "Vault PDA {} does not match configured blacklist authority {}",
+                vault_pda,
+                blacklist_authority
+            ));
+        }
+
+        println!("  Vault PDA: {}", vault_pda);
+        println!("  Transaction PDA: {}", transaction_pda);
+        println!("  Proposal PDA: {}", proposal_pda);
+
+        // Create the transaction message for the vault transaction
+        let message = TransactionMessage::try_compile(&vault_pda, &[deblacklist_ix], &[])?;
+
+        // Create vault transaction instruction
+        let vault_tx_ix = vault_transaction_create(
+            VaultTransactionCreateAccounts {
+                multisig,
+                transaction: transaction_pda,
+                creator: cli_signer.pubkey(),
+                rent_payer: cli_signer.pubkey(),
+                system_program: system_program::id(),
+            },
+            args.squads_vault_index,
+            0, // num_ephemeral_signers
+            &message,
+            Some("Remove validators from blacklist".to_string()),
+            Some(squads_program_id),
+        );
+
+        // Create proposal instruction
+        let proposal_ix = proposal_create(
+            ProposalCreateAccounts {
+                multisig,
+                creator: cli_signer.pubkey(),
+                proposal: proposal_pda,
+                rent_payer: cli_signer.pubkey(),
+                system_program: system_program::id(),
+            },
+            ProposalCreateArgs {
+                transaction_index,
+                draft: false,
+            },
+            Some(squads_program_id),
+        );
+
+        let blockhash = client.get_latest_blockhash().await?;
+
+        let configured_ixs = configure_instruction(
+            &[vault_tx_ix, proposal_ix],
+            args.permissioned_parameters
+                .transaction_parameters
+                .priority_fee,
+            args.permissioned_parameters
+                .transaction_parameters
+                .compute_limit,
+            args.permissioned_parameters
+                .transaction_parameters
+                .heap_size,
+        );
+
+        if !maybe_print_tx(
+            &configured_ixs,
+            &args.permissioned_parameters.transaction_parameters,
+        ) {
+            let transaction = Transaction::new_signed_with_payer(
+                &configured_ixs,
+                Some(&cli_signer.pubkey()),
+                &[&cli_signer],
+                blockhash,
+            );
+            let signature = client
+                .send_and_confirm_transaction_with_spinner(&transaction)
+                .await?;
+
+            println!("Squads proposal created!");
+            println!("Signature: {}", signature);
+        }
+    } else {
+        // Direct execution
+        let blockhash = client.get_latest_blockhash().await?;
+
+        let configured_ix = configure_instruction(
+            &[deblacklist_ix],
+            args.permissioned_parameters
+                .transaction_parameters
+                .priority_fee,
+            args.permissioned_parameters
+                .transaction_parameters
+                .compute_limit,
+            args.permissioned_parameters
+                .transaction_parameters
+                .heap_size,
+        );
+
+        if !maybe_print_tx(
+            &configured_ix,
+            &args.permissioned_parameters.transaction_parameters,
+        ) {
+            let transaction = Transaction::new_signed_with_payer(
+                &configured_ix,
+                Some(&cli_signer.pubkey()),
+                &[&cli_signer],
+                blockhash,
+            );
+            let signature = client
+                .send_and_confirm_transaction_with_spinner(&transaction)
+                .await?;
+
+            println!("Signature: {}", signature);
+        }
     }
 
     Ok(())

--- a/utils/steward-cli/src/commands/command_args.rs
+++ b/utils/steward-cli/src/commands/command_args.rs
@@ -622,6 +622,32 @@ pub struct RemoveFromBlacklist {
     /// Validator indices of validator list to remove (comma separated)
     #[arg(long, env, value_delimiter = ',', num_args = 1.., value_parser = parse_u32)]
     pub validator_history_indices_to_deblacklist: Vec<u32>,
+
+    /// Vote accounts of validators to remove from blacklist (comma separated)
+    #[arg(long, env, value_delimiter = ',', num_args = 1.., value_parser = parse_pubkey)]
+    pub vote_accounts_to_deblacklist: Vec<Pubkey>,
+
+    /// Create a Squads multisig proposal instead of direct execution
+    #[arg(long, env, default_value = "false")]
+    pub squads_proposal: bool,
+
+    /// Squads multisig account address.
+    /// Note: This is the Squads multisig account, NOT the vault PDA. The vault PDA will be derived from this
+    /// multisig address and will act as the signing authority for the blacklist operation.
+    #[arg(
+        long,
+        env,
+        default_value = "87zx3xqcWzP9DpGgbrNGnVsU6Dzci3XvaQvuTkgfWF5c"
+    )]
+    pub squads_multisig: Pubkey,
+
+    /// Vault index for the Squads multisig (default: 0)
+    #[arg(long, env, default_value = "0")]
+    pub squads_vault_index: u8,
+
+    /// Squads program ID (defaults to mainnet Squads v4 program)
+    #[arg(long, env)]
+    pub squads_program_id: Option<Pubkey>,
 }
 
 #[derive(Parser)]

--- a/utils/steward-cli/src/main.rs
+++ b/utils/steward-cli/src/main.rs
@@ -203,7 +203,15 @@ async fn main() -> Result<()> {
             command_add_to_blacklist(args, &client, steward_program_id, &cli_signer).await
         }
         Commands::RemoveFromBlacklist(args) => {
-            command_remove_from_blacklist(args, &client, steward_program_id).await
+            // Use global signer - required for this command
+            let signer_path = global_signer.expect("--signer flag is required for this command");
+            // Create the appropriate signer based on the path
+            let cli_signer = if signer_path == "ledger" {
+                CliSigner::new_ledger()
+            } else {
+                CliSigner::new_keypair_from_path(signer_path)?
+            };
+            command_remove_from_blacklist(args, &client, steward_program_id, &cli_signer).await
         }
         Commands::UpdateValidatorListBalance(args) => {
             command_update_validator_list_balance(&client, args, steward_program_id).await


### PR DESCRIPTION
Adds squads integration to the `remove-validators-from-blacklist`.

This is largely a copy pasta from the compliment instruction, `add-validators-to-blacklist`.