### PR TITLE
Steward: Fix directed rebalance ix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,7 +3113,7 @@ dependencies = [
 
 [[package]]
 name = "jito-steward"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anchor-lang",
  "bincode",

--- a/programs/steward/Cargo.toml
+++ b/programs/steward/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jito-steward"
-version = "0.3.0"
+version = "0.3.1"
 description = "Program for permissionlessly managing an SPL Stake Pool"
 edition = "2021"
 license = "Apache-2.0"

--- a/programs/steward/idl/steward.json
+++ b/programs/steward/idl/steward.json
@@ -2,7 +2,7 @@
   "address": "Stewardf95sJbmtcZsyagb2dg4Mo8eVQho8gpECvLx8",
   "metadata": {
     "name": "steward",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "spec": "0.1.0",
     "description": "Program for permissionlessly managing an SPL Stake Pool"
   },

--- a/programs/steward/src/instructions/rebalance_directed.rs
+++ b/programs/steward/src/instructions/rebalance_directed.rs
@@ -123,13 +123,16 @@ pub struct RebalanceDirected<'info> {
 ///   `total_staked_lamports` and `directed_stake_lamports` accordingly.
 /// - **Deposit** (`validator_list > steward_state` and applied < target): stake arrived externally;
 ///   credit up to the directed deficit against the deposit.
-/// - **Stale `total_staked_lamports`** (`applied > validator_list` while the two totals are equal):
-///   an undirected rebalance already synced `validator_lamport_balances` to the current on-chain
-///   value, but `total_staked_lamports` was not updated. This occurs when an external withdrawal
-///   (e.g. a JitoSOL redemption via `decrease_validator_stake_with_reserve`) is absorbed by the
-///   undirected rebalance before directed rebalance runs, making the withdrawal invisible to the
-///   normal withdrawal branch. Cap `total_staked_lamports` and `directed_stake_lamports` to the
-///   actual validator stake; `validator_lamport_balances` is left unchanged as it is already correct.
+/// - **Stale `total_staked_lamports`** : an undirected
+///   rebalance already synced `validator_lamport_balances` to the current on-chain value, but
+///   `total_staked_lamports` was not updated. This occurs when an external withdrawal (e.g. a
+///   JitoSOL redemption via `decrease_validator_stake_with_reserve`) is absorbed by the undirected
+///   rebalance before directed rebalance runs, leaving directed accounting stale and far too high.
+///   The deposit/withdrawal branches above are keyed on the delta and do not fire in that case, so
+///   this clamp is keyed directly on `applied > on-chain stake` and fires regardless of which
+///   branch ran — including the equal-totals case the bug exhibits.
+///   Cap `total_staked_lamports` and `directed_stake_lamports` to the actual validator stake;
+///   `validator_lamport_balances` is left unchanged as it is already correct.
 pub fn adjust_directed_stake_for_deposits_and_withdrawals(
     validator_list_staked_lamports: u64,
     validator_list_index: usize,
@@ -192,7 +195,12 @@ pub fn adjust_directed_stake_for_deposits_and_withdrawals(
         state_account.state.validator_lamport_balances[validator_list_index] =
             state_account.state.validator_lamport_balances[validator_list_index]
                 .saturating_add(increase_lamports);
-    } else if directed_stake_applied_lamports > validator_list_staked_lamports {
+    }
+
+    // Stale directed accounting clamp
+    let directed_stake_applied_lamports =
+        directed_stake_meta.targets[directed_stake_meta_index].total_staked_lamports;
+    if directed_stake_applied_lamports > validator_list_staked_lamports {
         let excess = directed_stake_applied_lamports.saturating_sub(validator_list_staked_lamports);
         directed_stake_meta.subtract_from_total_staked_lamports(directed_stake_meta_index, excess);
         directed_stake_meta.directed_stake_lamports[validator_list_index] = directed_stake_meta
@@ -816,16 +824,8 @@ mod tests {
         );
     }
 
-    /// test_adjust_directed_stake_stale_total_staked_after_undirected_rebalance
-    ///
-    /// Reproduces the LEVMA epoch 956 scenario:
-    ///
-    /// 1. External withdrawal drops validator stake from ~49,785 → ~5,166 SOL.
-    /// 2. Undirected rebalance syncs validator_lamport_balances to 5,166 SOL
-    ///    but does NOT update total_staked_lamports (49,612 SOL).
-    /// 3. Directed rebalance runs: validator_list == steward_state (both 5,166),
-    ///    so neither the withdrawal nor the deposit branch fires.
-    ///    Without the fix, total_staked_lamports would stay at 49,612 SOL.
+    /// The stale-accounting clamp must cap total_staked_lamports to the actual
+    /// validator stake while leaving validator_lamport_balances unchanged.
     #[test]
     fn test_adjust_directed_stake_stale_total_staked_after_undirected_rebalance() {
         let mut directed_stake_meta = create_default_directed_stake_meta();
@@ -861,7 +861,6 @@ mod tests {
         );
 
         assert!(result.is_ok());
-        // total_staked_lamports must be capped to the actual validator stake
         assert_eq!(
             directed_stake_meta.targets[directed_stake_meta_index].total_staked_lamports,
             validator_list_staked_lamports,

--- a/programs/steward/src/instructions/rebalance_directed.rs
+++ b/programs/steward/src/instructions/rebalance_directed.rs
@@ -1,7 +1,18 @@
-use crate::directed_delegation::{decrease_stake_calculation, increase_stake_calculation};
+use anchor_lang::{
+    prelude::*,
+    solana_program::{
+        program::invoke_signed,
+        stake::{self, state::StakeStateV2, tools::get_minimum_delegation},
+        system_program, sysvar,
+    },
+};
+use spl_stake_pool::{minimum_delegation, state::ValidatorListHeader};
+
 use crate::{
     constants::{LAMPORT_BALANCE_DEFAULT, STAKE_POOL_WITHDRAW_SEED},
-    directed_delegation::{RebalanceType, UnstakeState},
+    directed_delegation::{
+        decrease_stake_calculation, increase_stake_calculation, RebalanceType, UnstakeState,
+    },
     errors::StewardError,
     events::{DirectedRebalanceEvent, RebalanceTypeTag},
     maybe_transition,
@@ -14,15 +25,7 @@ use crate::{
     Config, StewardStateAccount, StewardStateAccountV2, StewardStateEnum,
     REBALANCE_DIRECTED_COMPLETE,
 };
-use anchor_lang::{
-    prelude::*,
-    solana_program::{
-        program::invoke_signed,
-        stake::{self, state::StakeStateV2, tools::get_minimum_delegation},
-        system_program, sysvar,
-    },
-};
-use spl_stake_pool::{minimum_delegation, state::ValidatorListHeader};
+
 #[derive(Accounts)]
 pub struct RebalanceDirected<'info> {
     pub config: AccountLoader<'info, Config>,
@@ -113,6 +116,20 @@ pub struct RebalanceDirected<'info> {
     pub stake_program: AccountInfo<'info>,
 }
 
+/// Reconciles directed stake accounting after external deposits or withdrawals.
+///
+/// Three cases are handled:
+/// - **Withdrawal** (`validator_list < steward_state`): stake was removed externally; reduce
+///   `total_staked_lamports` and `directed_stake_lamports` accordingly.
+/// - **Deposit** (`validator_list > steward_state` and applied < target): stake arrived externally;
+///   credit up to the directed deficit against the deposit.
+/// - **Stale `total_staked_lamports`** (`applied > validator_list` while the two totals are equal):
+///   an undirected rebalance already synced `validator_lamport_balances` to the current on-chain
+///   value, but `total_staked_lamports` was not updated. This occurs when an external withdrawal
+///   (e.g. a JitoSOL redemption via `decrease_validator_stake_with_reserve`) is absorbed by the
+///   undirected rebalance before directed rebalance runs, making the withdrawal invisible to the
+///   normal withdrawal branch. Cap `total_staked_lamports` and `directed_stake_lamports` to the
+///   actual validator stake; `validator_lamport_balances` is left unchanged as it is already correct.
 pub fn adjust_directed_stake_for_deposits_and_withdrawals(
     validator_list_staked_lamports: u64,
     validator_list_index: usize,
@@ -126,6 +143,7 @@ pub fn adjust_directed_stake_for_deposits_and_withdrawals(
         directed_stake_meta.targets[directed_stake_meta_index].total_target_lamports;
     let directed_stake_applied_lamports =
         directed_stake_meta.targets[directed_stake_meta_index].total_staked_lamports;
+
     if validator_list_staked_lamports < steward_state_total_lamports {
         let withdrawal_lamports =
             steward_state_total_lamports.saturating_sub(validator_list_staked_lamports);
@@ -174,7 +192,14 @@ pub fn adjust_directed_stake_for_deposits_and_withdrawals(
         state_account.state.validator_lamport_balances[validator_list_index] =
             state_account.state.validator_lamport_balances[validator_list_index]
                 .saturating_add(increase_lamports);
+    } else if directed_stake_applied_lamports > validator_list_staked_lamports {
+        let excess = directed_stake_applied_lamports.saturating_sub(validator_list_staked_lamports);
+        directed_stake_meta.subtract_from_total_staked_lamports(directed_stake_meta_index, excess);
+        directed_stake_meta.directed_stake_lamports[validator_list_index] = directed_stake_meta
+            .directed_stake_lamports[validator_list_index]
+            .saturating_sub(excess);
     }
+
     Ok(())
 }
 
@@ -788,6 +813,67 @@ mod tests {
         assert_eq!(
             state_account.state.validator_lamport_balances[validator_list_index],
             steward_state_total_lamports.saturating_sub(withdrawal_lamports)
+        );
+    }
+
+    /// test_adjust_directed_stake_stale_total_staked_after_undirected_rebalance
+    ///
+    /// Reproduces the LEVMA epoch 956 scenario:
+    ///
+    /// 1. External withdrawal drops validator stake from ~49,785 → ~5,166 SOL.
+    /// 2. Undirected rebalance syncs validator_lamport_balances to 5,166 SOL
+    ///    but does NOT update total_staked_lamports (49,612 SOL).
+    /// 3. Directed rebalance runs: validator_list == steward_state (both 5,166),
+    ///    so neither the withdrawal nor the deposit branch fires.
+    ///    Without the fix, total_staked_lamports would stay at 49,612 SOL.
+    #[test]
+    fn test_adjust_directed_stake_stale_total_staked_after_undirected_rebalance() {
+        let mut directed_stake_meta = create_default_directed_stake_meta();
+        let validator_list_index = 0;
+        let directed_stake_meta_index = 0;
+
+        let validator_list_staked_lamports = 5_166_000_000_000u64; // current on-chain
+        let steward_state_total_lamports = 5_166_000_000_000u64; // already synced by undirected
+        let directed_stake_target_lamports = 49_785_000_000_000u64;
+        let directed_stake_applied_lamports = 49_612_000_000_000u64; // stale
+
+        let mut state_account = create_default_steward_state_account();
+        state_account.state.validator_lamport_balances[validator_list_index] =
+            steward_state_total_lamports;
+
+        directed_stake_meta.targets[directed_stake_meta_index] = DirectedStakeTarget {
+            vote_pubkey: Pubkey::default(),
+            total_target_lamports: directed_stake_target_lamports,
+            total_staked_lamports: directed_stake_applied_lamports,
+            target_last_updated_epoch: 0,
+            staked_last_updated_epoch: 0,
+            _padding0: [0; 32],
+        };
+        directed_stake_meta.directed_stake_lamports[validator_list_index] =
+            directed_stake_applied_lamports;
+
+        let result = adjust_directed_stake_for_deposits_and_withdrawals(
+            validator_list_staked_lamports,
+            validator_list_index,
+            directed_stake_meta_index,
+            &mut directed_stake_meta,
+            &mut state_account,
+        );
+
+        assert!(result.is_ok());
+        // total_staked_lamports must be capped to the actual validator stake
+        assert_eq!(
+            directed_stake_meta.targets[directed_stake_meta_index].total_staked_lamports,
+            validator_list_staked_lamports,
+        );
+        assert_eq!(
+            directed_stake_meta.directed_stake_lamports[validator_list_index],
+            validator_list_staked_lamports,
+        );
+        // validator_lamport_balances must be unchanged (already correct from undirected rebalance)
+        assert_eq!(
+            state_account.state.validator_lamport_balances[validator_list_index],
+            steward_state_total_lamports,
         );
     }
 }

--- a/programs/steward/src/state/steward_state.rs
+++ b/programs/steward/src/state/steward_state.rs
@@ -903,6 +903,27 @@ impl StewardStateV2 {
         Err(StewardError::InvalidState.into())
     }
 
+    /// Simulates the on-chain reconciliation performed by
+    /// `adjust_directed_stake_for_deposits_and_withdrawals` in `rebalance_directed.rs`,
+    /// returning the post-state `(new_directed_stake_lamports, new_total_stake_lamports)`
+    /// for a single validator without mutating any account. Used by scoring and rebalance
+    /// calculations (see `delegation.rs::{increase,decrease}_stake_calculation`) so they
+    /// see the same totals the on-chain instruction would write — keeping their branches
+    /// in sync is required for scoring/rebalance correctness.
+    ///
+    /// Returns `(0, target_total_staked_lamports)` when no directed-stake target is wired
+    /// up for this validator (`directed_stake_meta_indices[i] == u64::MAX`).
+    ///
+    /// Otherwise handles three cases mirroring the on-chain instruction:
+    /// - **Withdrawal** (`target_total < steward_state`): subtract the withdrawal from
+    ///   directed accounting, rolling any remainder over to undirected stake.
+    /// - **Deposit** (`target_total > steward_state` and applied < target): credit up to
+    ///   the directed deficit against the deposit.
+    /// - **Stale `total_staked_lamports`** (`applied > target_total`): an undirected
+    ///   rebalance has already synced `validator_lamport_balances` to the validator list,
+    ///   but the directed accounting wasn't updated. Cap `directed_stake_lamports[i]` to
+    ///   the validator list stake; `new_total_stake_lamports` is left at the current
+    ///   `validator_lamport_balances[i]` because it is already correct.
     pub fn simulate_adjust_directed_stake_for_deposits_and_withdrawals(
         &self,
         target_total_staked_lamports: u64,
@@ -913,12 +934,14 @@ impl StewardStateV2 {
         if directed_stake_meta.directed_stake_meta_indices[validator_list_index] == u64::MAX {
             return Ok((0, target_total_staked_lamports));
         }
+
         let (mut new_directed_stake_lamports, mut new_total_stake_lamports) = (0u64, 0u64);
         let steward_state_total_lamports = self.validator_lamport_balances[validator_list_index];
         let directed_stake_target_lamports =
             directed_stake_meta.targets[directed_stake_meta_index].total_target_lamports;
         let directed_stake_applied_lamports =
             directed_stake_meta.targets[directed_stake_meta_index].total_staked_lamports;
+
         if target_total_staked_lamports < steward_state_total_lamports {
             let withdrawal_lamports =
                 steward_state_total_lamports.saturating_sub(target_total_staked_lamports);
@@ -957,7 +980,15 @@ impl StewardStateV2 {
                 .saturating_add(increase_lamports);
             new_total_stake_lamports = self.validator_lamport_balances[validator_list_index]
                 .saturating_add(increase_lamports);
+        } else if directed_stake_applied_lamports > target_total_staked_lamports {
+            let excess =
+                directed_stake_applied_lamports.saturating_sub(target_total_staked_lamports);
+            new_directed_stake_lamports = directed_stake_meta.directed_stake_lamports
+                [validator_list_index]
+                .saturating_sub(excess);
+            new_total_stake_lamports = steward_state_total_lamports;
         }
+
         Ok((new_directed_stake_lamports, new_total_stake_lamports))
     }
 
@@ -1241,7 +1272,7 @@ pub fn select_validators_to_delegate(
 
 #[cfg(test)]
 mod tests {
-    use crate::constants::SORTED_INDEX_DEFAULT;
+    use crate::{constants::SORTED_INDEX_DEFAULT, utils::U8Bool, DirectedStakeTarget};
 
     use super::*;
 
@@ -1412,5 +1443,178 @@ mod tests {
         state.transition_idle(20, 0.3, 0.9, 0.5).unwrap();
         assert!(matches!(state.state_tag, StewardStateEnum::Idle));
         assert!(state.has_flag(PRE_LOOP_IDLE));
+    }
+
+    /// Builds a `DirectedStakeMeta` with the given targets. All
+    /// `directed_stake_meta_indices` start as `u64::MAX` (i.e. unlinked); use
+    /// [`link_directed_target`] to wire a validator-list index to a target.
+    fn make_directed_stake_meta(targets: &[(Pubkey, u64, u64)]) -> DirectedStakeMeta {
+        let mut meta = DirectedStakeMeta {
+            total_stake_targets: 0,
+            directed_unstake_total: 0,
+            padding0: [0; 63],
+            is_initialized: U8Bool::from(true),
+            directed_stake_lamports: [0; MAX_VALIDATORS],
+            directed_stake_meta_indices: [u64::MAX; MAX_VALIDATORS],
+            targets: [DirectedStakeTarget {
+                vote_pubkey: Pubkey::default(),
+                total_target_lamports: 0,
+                total_staked_lamports: 0,
+                target_last_updated_epoch: 0,
+                staked_last_updated_epoch: 0,
+                _padding0: [0; 32],
+            }; MAX_VALIDATORS],
+        };
+        for (i, (vote_pubkey, target_lamports, staked_lamports)) in targets.iter().enumerate() {
+            meta.targets[i] = DirectedStakeTarget {
+                vote_pubkey: *vote_pubkey,
+                total_target_lamports: *target_lamports,
+                total_staked_lamports: *staked_lamports,
+                target_last_updated_epoch: 0,
+                staked_last_updated_epoch: 0,
+                _padding0: [0; 32],
+            };
+        }
+        meta.total_stake_targets = targets.len() as u64;
+        meta
+    }
+
+    /// Wires a directed-stake target at `validator_list_index` so the simulator runs
+    /// past its `u64::MAX` early-return. Sets `directed_stake_meta_indices` and the
+    /// per-validator `directed_stake_lamports` mirror that the on-chain instruction
+    /// keeps in sync with `targets[..].total_staked_lamports`.
+    fn link_directed_target(
+        meta: &mut DirectedStakeMeta,
+        validator_list_index: usize,
+        target_index: usize,
+        directed_stake_lamports: u64,
+    ) {
+        meta.directed_stake_meta_indices[validator_list_index] = target_index as u64;
+        meta.directed_stake_lamports[validator_list_index] = directed_stake_lamports;
+    }
+
+    #[test]
+    fn no_meta_entry_returns_validator_list_stake() {
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 7_000_000;
+        let meta = make_directed_stake_meta(&[]);
+
+        // `directed_stake_meta_indices[0]` is u64::MAX, so the simulator should
+        // short-circuit and report no directed stake with the validator list's total.
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(10_000_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 0);
+        assert_eq!(new_total, 10_000_000);
+    }
+
+    #[test]
+    fn withdrawal_exceeds_directed_rolls_over_to_undirected() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 25_000_000;
+        let mut meta = make_directed_stake_meta(&[(validator1, 1_000_000, 1_000_000)]);
+        link_directed_target(&mut meta, 0, 0, 1_000_000);
+
+        // 3M withdrawal, directed_applied (1M) < withdrawal (3M): directed drops
+        // to 0, remainder is absorbed by undirected via the full subtraction on
+        // total.
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(22_000_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 0);
+        assert_eq!(new_total, 22_000_000);
+    }
+
+    #[test]
+    fn withdrawal_within_directed() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 25_000_000;
+        let mut meta = make_directed_stake_meta(&[(validator1, 5_000_000, 5_000_000)]);
+        link_directed_target(&mut meta, 0, 0, 5_000_000);
+
+        // 3M withdrawal, directed_applied (5M) >= withdrawal (3M): both directed
+        // and total drop by the withdrawal amount.
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(22_000_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 2_000_000);
+        assert_eq!(new_total, 22_000_000);
+    }
+
+    #[test]
+    fn deposit_credits_directed_deficit() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 20_000_000;
+        // target_lamports = 3M, applied = 1M => directed deficit = 2M
+        let mut meta = make_directed_stake_meta(&[(validator1, 3_000_000, 1_000_000)]);
+        link_directed_target(&mut meta, 0, 0, 1_000_000);
+
+        // 5M deposit, capped to the 2M deficit.
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(25_000_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 3_000_000);
+        assert_eq!(new_total, 22_000_000);
+    }
+
+    #[test]
+    fn deposit_smaller_than_deficit() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 20_000_000;
+        // directed deficit = 10M
+        let mut meta = make_directed_stake_meta(&[(validator1, 11_000_000, 1_000_000)]);
+        link_directed_target(&mut meta, 0, 0, 1_000_000);
+
+        // Only 500k deposit, less than the deficit; full deposit goes to directed.
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(20_500_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 1_500_000);
+        assert_eq!(new_total, 20_500_000);
+    }
+
+    /// Mirrors the stale-`total_staked_lamports` branch added in
+    /// rebalance_directed.rs: an earlier undirected rebalance already synced
+    /// `validator_lamport_balances` to the current on-chain validator list,
+    /// but directed accounting wasn't updated.
+    #[test]
+    fn stale_case_caps_directed_to_validator_list() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        // steward_state_total_lamports == validator list reports == 5M
+        state.validator_lamport_balances[0] = 5_000_000;
+        // directed_applied = 6M (stale; exceeds the validator list).
+        let mut meta = make_directed_stake_meta(&[(validator1, 6_000_000, 6_000_000)]);
+        link_directed_target(&mut meta, 0, 0, 6_000_000);
+
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(5_000_000, 0, 0, &meta)
+            .unwrap();
+        // Excess of 1M is removed from directed; total left unchanged.
+        assert_eq!(new_directed, 5_000_000);
+        assert_eq!(new_total, 5_000_000);
+    }
+
+    /// Defensive: if directed_stake_lamports has drifted below
+    /// targets.total_staked_lamports for some reason, the saturating_sub
+    /// must not underflow.
+    #[test]
+    fn stale_case_saturates_when_excess_exceeds_directed_lamports() {
+        let validator1 = Pubkey::new_unique();
+        let mut state = default_state();
+        state.validator_lamport_balances[0] = 1_000_000;
+        let mut meta = make_directed_stake_meta(&[(validator1, 6_000_000, 6_000_000)]);
+        // Set the per-validator mirror below the excess (5M) to trigger saturation.
+        link_directed_target(&mut meta, 0, 0, 3_000_000);
+
+        let (new_directed, new_total) = state
+            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(1_000_000, 0, 0, &meta)
+            .unwrap();
+        assert_eq!(new_directed, 0);
+        assert_eq!(new_total, 1_000_000);
     }
 }

--- a/programs/steward/src/state/steward_state.rs
+++ b/programs/steward/src/state/steward_state.rs
@@ -935,7 +935,9 @@ impl StewardStateV2 {
             return Ok((0, target_total_staked_lamports));
         }
 
-        let (mut new_directed_stake_lamports, mut new_total_stake_lamports) = (0u64, 0u64);
+        let mut new_directed_stake_lamports;
+        let new_total_stake_lamports;
+
         let steward_state_total_lamports = self.validator_lamport_balances[validator_list_index];
         let directed_stake_target_lamports =
             directed_stake_meta.targets[directed_stake_meta_index].total_target_lamports;
@@ -980,13 +982,14 @@ impl StewardStateV2 {
                 .saturating_add(increase_lamports);
             new_total_stake_lamports = self.validator_lamport_balances[validator_list_index]
                 .saturating_add(increase_lamports);
-        } else if directed_stake_applied_lamports > target_total_staked_lamports {
-            let excess =
-                directed_stake_applied_lamports.saturating_sub(target_total_staked_lamports);
-            new_directed_stake_lamports = directed_stake_meta.directed_stake_lamports
-                [validator_list_index]
-                .saturating_sub(excess);
+        } else {
+            new_directed_stake_lamports =
+                directed_stake_meta.directed_stake_lamports[validator_list_index];
             new_total_stake_lamports = steward_state_total_lamports;
+        }
+
+        if new_directed_stake_lamports > target_total_staked_lamports {
+            new_directed_stake_lamports = target_total_staked_lamports;
         }
 
         Ok((new_directed_stake_lamports, new_total_stake_lamports))
@@ -1272,7 +1275,7 @@ pub fn select_validators_to_delegate(
 
 #[cfg(test)]
 mod tests {
-    use crate::{constants::SORTED_INDEX_DEFAULT, utils::U8Bool, DirectedStakeTarget};
+    use crate::constants::SORTED_INDEX_DEFAULT;
 
     use super::*;
 
@@ -1445,176 +1448,26 @@ mod tests {
         assert!(state.has_flag(PRE_LOOP_IDLE));
     }
 
-    /// Builds a `DirectedStakeMeta` with the given targets. All
-    /// `directed_stake_meta_indices` start as `u64::MAX` (i.e. unlinked); use
-    /// [`link_directed_target`] to wire a validator-list index to a target.
-    fn make_directed_stake_meta(targets: &[(Pubkey, u64, u64)]) -> DirectedStakeMeta {
-        let mut meta = DirectedStakeMeta {
-            total_stake_targets: 0,
-            directed_unstake_total: 0,
-            padding0: [0; 63],
-            is_initialized: U8Bool::from(true),
-            directed_stake_lamports: [0; MAX_VALIDATORS],
-            directed_stake_meta_indices: [u64::MAX; MAX_VALIDATORS],
-            targets: [DirectedStakeTarget {
-                vote_pubkey: Pubkey::default(),
-                total_target_lamports: 0,
-                total_staked_lamports: 0,
-                target_last_updated_epoch: 0,
-                staked_last_updated_epoch: 0,
-                _padding0: [0; 32],
-            }; MAX_VALIDATORS],
-        };
-        for (i, (vote_pubkey, target_lamports, staked_lamports)) in targets.iter().enumerate() {
-            meta.targets[i] = DirectedStakeTarget {
-                vote_pubkey: *vote_pubkey,
-                total_target_lamports: *target_lamports,
-                total_staked_lamports: *staked_lamports,
-                target_last_updated_epoch: 0,
-                staked_last_updated_epoch: 0,
-                _padding0: [0; 32],
-            };
-        }
-        meta.total_stake_targets = targets.len() as u64;
-        meta
-    }
-
-    /// Wires a directed-stake target at `validator_list_index` so the simulator runs
-    /// past its `u64::MAX` early-return. Sets `directed_stake_meta_indices` and the
-    /// per-validator `directed_stake_lamports` mirror that the on-chain instruction
-    /// keeps in sync with `targets[..].total_staked_lamports`.
-    fn link_directed_target(
-        meta: &mut DirectedStakeMeta,
-        validator_list_index: usize,
-        target_index: usize,
-        directed_stake_lamports: u64,
-    ) {
-        meta.directed_stake_meta_indices[validator_list_index] = target_index as u64;
-        meta.directed_stake_lamports[validator_list_index] = directed_stake_lamports;
-    }
-
     #[test]
-    fn no_meta_entry_returns_validator_list_stake() {
+    fn test_simulate_adjust_directed_stale_total_staked() {
         let mut state = default_state();
-        state.validator_lamport_balances[0] = 7_000_000;
-        let meta = make_directed_stake_meta(&[]);
-
-        // `directed_stake_meta_indices[0]` is u64::MAX, so the simulator should
-        // short-circuit and report no directed stake with the validator list's total.
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(10_000_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 0);
-        assert_eq!(new_total, 10_000_000);
-    }
-
-    #[test]
-    fn withdrawal_exceeds_directed_rolls_over_to_undirected() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        state.validator_lamport_balances[0] = 25_000_000;
-        let mut meta = make_directed_stake_meta(&[(validator1, 1_000_000, 1_000_000)]);
-        link_directed_target(&mut meta, 0, 0, 1_000_000);
-
-        // 3M withdrawal, directed_applied (1M) < withdrawal (3M): directed drops
-        // to 0, remainder is absorbed by undirected via the full subtraction on
-        // total.
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(22_000_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 0);
-        assert_eq!(new_total, 22_000_000);
-    }
-
-    #[test]
-    fn withdrawal_within_directed() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        state.validator_lamport_balances[0] = 25_000_000;
-        let mut meta = make_directed_stake_meta(&[(validator1, 5_000_000, 5_000_000)]);
-        link_directed_target(&mut meta, 0, 0, 5_000_000);
-
-        // 3M withdrawal, directed_applied (5M) >= withdrawal (3M): both directed
-        // and total drop by the withdrawal amount.
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(22_000_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 2_000_000);
-        assert_eq!(new_total, 22_000_000);
-    }
-
-    #[test]
-    fn deposit_credits_directed_deficit() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        state.validator_lamport_balances[0] = 20_000_000;
-        // target_lamports = 3M, applied = 1M => directed deficit = 2M
-        let mut meta = make_directed_stake_meta(&[(validator1, 3_000_000, 1_000_000)]);
-        link_directed_target(&mut meta, 0, 0, 1_000_000);
-
-        // 5M deposit, capped to the 2M deficit.
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(25_000_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 3_000_000);
-        assert_eq!(new_total, 22_000_000);
-    }
-
-    #[test]
-    fn deposit_smaller_than_deficit() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        state.validator_lamport_balances[0] = 20_000_000;
-        // directed deficit = 10M
-        let mut meta = make_directed_stake_meta(&[(validator1, 11_000_000, 1_000_000)]);
-        link_directed_target(&mut meta, 0, 0, 1_000_000);
-
-        // Only 500k deposit, less than the deficit; full deposit goes to directed.
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(20_500_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 1_500_000);
-        assert_eq!(new_total, 20_500_000);
-    }
-
-    /// Mirrors the stale-`total_staked_lamports` branch added in
-    /// rebalance_directed.rs: an earlier undirected rebalance already synced
-    /// `validator_lamport_balances` to the current on-chain validator list,
-    /// but directed accounting wasn't updated.
-    #[test]
-    fn stale_case_caps_directed_to_validator_list() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        // steward_state_total_lamports == validator list reports == 5M
+        // validator_lamport_balances already synced down to 5M.
         state.validator_lamport_balances[0] = 5_000_000;
-        // directed_applied = 6M (stale; exceeds the validator list).
-        let mut meta = make_directed_stake_meta(&[(validator1, 6_000_000, 6_000_000)]);
-        link_directed_target(&mut meta, 0, 0, 6_000_000);
+
+        let mut meta = DirectedStakeMeta::default();
+        // Wire validator-list index 0 to target 0 so we run past the u64::MAX guard.
+        meta.directed_stake_meta_indices[0] = 0;
+        meta.total_stake_targets = 1;
+        meta.targets[0].total_target_lamports = 6_000_000;
+        meta.targets[0].total_staked_lamports = 6_000_000; // stale, exceeds on-chain
+        meta.directed_stake_lamports[0] = 6_000_000;
 
         let (new_directed, new_total) = state
             .simulate_adjust_directed_stake_for_deposits_and_withdrawals(5_000_000, 0, 0, &meta)
             .unwrap();
-        // Excess of 1M is removed from directed; total left unchanged.
+
+        // Directed capped to the on-chain stake; total unchanged (already correct).
         assert_eq!(new_directed, 5_000_000);
         assert_eq!(new_total, 5_000_000);
-    }
-
-    /// Defensive: if directed_stake_lamports has drifted below
-    /// targets.total_staked_lamports for some reason, the saturating_sub
-    /// must not underflow.
-    #[test]
-    fn stale_case_saturates_when_excess_exceeds_directed_lamports() {
-        let validator1 = Pubkey::new_unique();
-        let mut state = default_state();
-        state.validator_lamport_balances[0] = 1_000_000;
-        let mut meta = make_directed_stake_meta(&[(validator1, 6_000_000, 6_000_000)]);
-        // Set the per-validator mirror below the excess (5M) to trigger saturation.
-        link_directed_target(&mut meta, 0, 0, 3_000_000);
-
-        let (new_directed, new_total) = state
-            .simulate_adjust_directed_stake_for_deposits_and_withdrawals(1_000_000, 0, 0, &meta)
-            .unwrap();
-        assert_eq!(new_directed, 0);
-        assert_eq!(new_total, 1_000_000);
     }
 }


### PR DESCRIPTION
## Problem

When an external withdrawal occurs (e.g. a JitoSOL redemption via `decrease_validator_stake_with_reserve`), the undirected rebalance may run before the directed rebalance and sync `validator_lamport_balances` to the current on-chain validator stake. However, it does **not** update the directed stake accounting fields (`total_staked_lamports`, `directed_stake_lamports`).

When directed rebalance subsequently runs, neither existing branch fires:
- The **withdrawal branch** (`validator_list < steward_state`) does not fire because `validator_lamport_balances` was already synced.
- The **deposit branch** (`validator_list > steward_state`) does not fire because there was no new deposit.

As a result, `total_staked_lamports` and `directed_stake_lamports` remain stale - far above the actual on-chain validator stake - causing incorrect scoring and rebalance calculations downstream.

This was observed in production with LEVMA at epoch 956, where validator stake dropped from ~49,785 SOL to ~5,166 SOL but directed accounting remained at ~49,612 SOL.

Epoch 956

Big withdrawal:
https://solscan.io/tx/3DUfFxgajcCs1ZL5y9Hd6D8iJcKeujcSDoDg7YVNNwHm9k7SZCfw8MYVmQXEw65dy5fBroPgcSYMp17S4PKvux3k

<img width="4296" height="742" alt="image"
src="https://github.com/user-attachments/assets/94d64807-7a47-4a6a-a3d9-625d68d849ee" />


## Solution

- Add a third branch (`else if directed_stake_applied_lamports > validator_list_staked_lamports`) to
`adjust_directed_stake_for_deposits_and_withdrawals` that caps `total_staked_lamports` and `directed_stake_lamports` down to the actual on-chain validator stake. `validator_lamport_balances` is left unchanged since it is already correct after the undirected rebalance.

- The same branch is mirrored in `simulate_adjust_directed_stake_for_deposits_and_withdrawals` in `steward_state.rs` to keep scoring and rebalance calculations in sync with what the on-chain instruction writes.