### PR TITLE
Keeper, CLI: Use BAM connection rate to determine BAM-connected validators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3231,9 +3231,9 @@ dependencies = [
 
 [[package]]
 name = "kobe-client"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9299da4a4d7523db4664b164178c64f9ca822978e7ffdb0be9b226decee04c7"
+checksum = "cdf29409c3f60f9b6b2f0aba6b03c68bafb108a12e6990becd4ee00b9542fb59"
 dependencies = [
  "chrono",
  "reqwest 0.12.24",
@@ -11233,7 +11233,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakenet-keeper"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anchor-lang",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ jito-priority-fee-distribution = { features = ["no-entrypoint"], git = "https://
 jito-steward = { path = "programs/steward", features = ["no-entrypoint"] }
 jito-tip-distribution = { features = ["no-entrypoint"], git = "https://github.com/jito-foundation/jito-programs", branch = "master" }
 jito-tip-distribution-sdk = { git = "https://github.com/jito-foundation/jito-programs", branch = "master" }
-kobe-client = "0.2.0"
+kobe-client = "0.3.0"
 log = "0.4.18"
 reqwest = { version = "0.11.27", features = ["json"] }
 serde = "1.0.183"

--- a/keepers/stakenet-keeper/Cargo.toml
+++ b/keepers/stakenet-keeper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakenet-keeper"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Script to keep validator history accounts up to date"
 

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -1,8 +1,28 @@
-/*
-This program starts several threads to manage the creation of validator history accounts,
-and the updating of the various data feeds within the accounts.
-It will emits metrics for each data feed, if env var SOLANA_METRICS_CONFIG is set to a valid influx server.
-*/
+//* This program starts several threads to manage the creation of validator history accounts,
+//* and the updating of the various data feeds within the accounts.
+//* It will emit metrics for each data feed, if env var SOLANA_METRICS_CONFIG is set to a valid influx server.
+//*
+//* The main loop fires operations on fixed tick intervals (see `should_fire`/`should_update`), but
+//* WHEN within an epoch each operation actually does work is decided by per-operation gating, NOT by
+//* this loop. There are three patterns:
+//*
+//*  1. Epoch-progress gated in the keeper (each op's `_should_run` checks epoch_info.slot_index):
+//*       ~0% / 50% / 90%  vote_account, cluster_history, stake_upload, gossip_upload (3 runs/epoch)
+//*       10%              copy_is_bam_connected (1 run/epoch)
+//*
+//*  2. Steward — the keeper is purely reactive and just cranks whatever state the on-chain state
+//*     machine is currently in. The epoch-progress timeline is governed by the steward `Parameters`
+//*     (config-driven; defaults shown), not by this loop:
+//*       0% ──────────────► 50% ──────────────────► 90% ────────────────► 100%
+//*       RebalanceDirected   ComputeScores            ComputeInstantUnstake
+//*       (until ~50%, then   → ComputeDelegations      → Rebalance
+//*        forced to Idle at  (compute_score_           (instant_unstake_
+//*        compute_score_      epoch_progress = 0.5)     epoch_progress = 0.9)
+//*        epoch_progress)
+//*
+//*  3. No epoch gate — run on every tick their interval fires (`_should_run` returns `true`):
+//*       mev_commission, mev_earned, priority_fee_commission, block_metadata, metrics_emit
+
 use clap::Parser;
 use dotenvy::dotenv;
 use kobe_client::client_builder::KobeApiClientBuilder;
@@ -465,6 +485,7 @@ fn main() {
             validator_history_min_stake: args.validator_history_min_stake,
             kobe_client,
             coinbase_vote_pubkey: args.coinbase_vote_pubkey,
+            min_bam_connection_rate: args.min_bam_connection_rate,
         };
 
         run_keeper(config).await;

--- a/keepers/stakenet-keeper/src/operations/copy_is_jito_bam_connected.rs
+++ b/keepers/stakenet-keeper/src/operations/copy_is_jito_bam_connected.rs
@@ -1,12 +1,13 @@
 //! Copies the Jito BAM client status for each validator
 //! into their respective ValidatorHistory accounts.
 //!
-//! This operation queries the Kobe API to determine which validators are registered
-//! BAM clients, then writes a boolean flag (`is_bam_connected`) to each validator's
-//! on-chain history entry for the current epoch.
+//! This operation queries the Kobe API for validator stats from the previous epoch and
+//! marks a validator as BAM-connected when its reported `bam_connection_rate` meets the
+//! configured `min_bam_connection_rate` threshold, then writes a boolean flag
+//! (`is_bam_connected`) to each validator's on-chain history entry for that epoch.
 //!
-//! The operation runs at 30%, 60%, and 90% epoch completion to ensure BAM connection
-//! data is captured, spaced out to avoid missing all runs if the keeper is down late in the epoch.
+//! The operation runs once at 10% epoch completion, timed to avoid missing the run
+//! entirely if the keeper is down late in the epoch.
 
 use std::{collections::HashSet, str::FromStr, sync::Arc};
 
@@ -89,12 +90,10 @@ impl<'a> CopyIsBamConnectedOperation<'a> {
 
     /// Returns `true` when the operation should execute.
     ///
-    /// Runs up to 3 times per epoch at 30%, 60%, and 90% slot completion.
-    /// Spaced out to avoid missing all runs if the keeper is down late in the epoch.
+    /// Runs once per epoch after 10% slot completion.
+    /// Timed to avoid missing the run entirely if the keeper is down late in the epoch.
     fn should_run(epoch_info: &EpochInfo, runs_for_epoch: u64) -> bool {
-        (epoch_info.slot_index > epoch_info.slots_in_epoch * 30 / 100 && runs_for_epoch < 1)
-            || (epoch_info.slot_index > epoch_info.slots_in_epoch * 60 / 100 && runs_for_epoch < 2)
-            || (epoch_info.slot_index > epoch_info.slots_in_epoch * 90 / 100 && runs_for_epoch < 3)
+        epoch_info.slot_index > epoch_info.slots_in_epoch * 10 / 100 && runs_for_epoch < 1
     }
 
     /// Entry point for the operation. Checks whether the operation should run,
@@ -142,6 +141,7 @@ impl<'a> CopyIsBamConnectedOperation<'a> {
     /// for all validators
     async fn process(&self) -> Result<SubmitStats, JitoTransactionError> {
         let epoch_info = &self.keeper_state.epoch_info;
+        let last_epoch = epoch_info.epoch.saturating_sub(1);
         let validator_history_map = &self.keeper_state.validator_history_map;
         let candidates: Vec<Pubkey> = validator_history_map.keys().copied().collect();
 
@@ -165,17 +165,26 @@ impl<'a> CopyIsBamConnectedOperation<'a> {
             .filter(|pubkey| live_vote_accounts.contains(pubkey))
             .collect();
 
-        let bam_validators = self
+        let validators = self
             .keeper_config
             .kobe_client
-            .get_bam_validators(epoch_info.epoch)
+            .get_validators(Some(last_epoch))
             .await
             .map_err(|e| JitoTransactionError::Custom(e.to_string()))?
-            .bam_validators;
+            .validators;
 
-        let bam_vote_accounts: HashSet<Pubkey> = bam_validators
+        let bam_vote_accounts: HashSet<Pubkey> = validators
             .iter()
-            .filter_map(|bam_v| Pubkey::from_str(&bam_v.vote_account).ok())
+            .filter_map(|bam_v| {
+                let vote_account = Pubkey::from_str(&bam_v.vote_account).ok()?;
+                let connection_rate = bam_v.bam_connection_rate?;
+
+                if connection_rate >= self.keeper_config.min_bam_connection_rate {
+                    return Some(vote_account);
+                }
+
+                None
+            })
             .collect();
 
         let update_instructions = entries_to_update
@@ -187,7 +196,7 @@ impl<'a> CopyIsBamConnectedOperation<'a> {
                     *vote_account,
                     &self.program_id,
                     &self.oracle_authority_keypair.pubkey(),
-                    epoch_info.epoch,
+                    last_epoch,
                     is_bam_connected,
                 )
                 .update_instruction()

--- a/keepers/stakenet-keeper/src/state/keeper_config.rs
+++ b/keepers/stakenet-keeper/src/state/keeper_config.rs
@@ -58,6 +58,9 @@ pub struct KeeperConfig {
 
     /// A coinbase vote pubkey
     pub coinbase_vote_pubkey: Pubkey,
+
+    /// Minimum BAM connection rate for a validator to be considered BAM-connected
+    pub min_bam_connection_rate: f64,
 }
 
 impl KeeperConfig {
@@ -283,6 +286,24 @@ pub struct Args {
         default_value = "DyjoG2US2XiVvL1MVzL2wjS5jCTmvo6aNwvqJfaPNx9u"
     )]
     pub coinbase_vote_pubkey: Pubkey,
+
+    /// Minimum BAM connection rate for a validator to be considered BAM-connected
+    #[arg(long, env, value_parser = parse_connection_rate)]
+    pub min_bam_connection_rate: f64,
+}
+
+/// Parses a connection rate, validating it falls within the inclusive range `0.0..=1.0`.
+fn parse_connection_rate(s: &str) -> Result<f64, String> {
+    let v: f64 = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a valid number"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!(
+            "connection rate must be between 0.0 and 1.0, got {v}"
+        ))
+    }
 }
 
 impl fmt::Display for Args {
@@ -335,6 +356,7 @@ impl fmt::Display for Args {
             Run Copy Is BAM Connected Operation: {:?}\n\
             Kobe API Base URL: {:?}\n\
             Coinbase Vote Pubkey: {:?}\n\
+            Min BAM Connection Rate: {:?}\n\
             -------------------------------",
             self.json_rpc_url,
             self.gossip_entrypoints,
@@ -379,7 +401,8 @@ impl fmt::Display for Args {
             self.run_directed_staking,
             self.run_copy_is_bam_connected,
             self.kobe_api_base_url,
-            self.coinbase_vote_pubkey
+            self.coinbase_vote_pubkey,
+            self.min_bam_connection_rate,
         )
     }
 }

--- a/utils/validator-history-cli/src/commands/cranks/copy_is_bam_connected.rs
+++ b/utils/validator-history-cli/src/commands/cranks/copy_is_bam_connected.rs
@@ -28,6 +28,24 @@ pub struct CrankCopyIsBamConnected {
     /// Epoch number
     #[arg(long)]
     epoch: Option<u64>,
+
+    /// Minimum BAM connection rate for a validator to be considered BAM-connected
+    #[arg(long, value_parser = parse_connection_rate)]
+    min_bam_connection_rate: f64,
+}
+
+/// Parses a connection rate, validating it falls within the inclusive range `0.0..=1.0`.
+fn parse_connection_rate(s: &str) -> Result<f64, String> {
+    let v: f64 = s
+        .parse()
+        .map_err(|_| format!("`{s}` is not a valid number"))?;
+    if (0.0..=1.0).contains(&v) {
+        Ok(v)
+    } else {
+        Err(format!(
+            "connection rate must be between 0.0 and 1.0, got {v}"
+        ))
+    }
 }
 
 /// Maximum number of accounts per `get_multiple_accounts` RPC call.
@@ -42,6 +60,7 @@ pub async fn run(args: CrankCopyIsBamConnected, rpc_url: String) -> anyhow::Resu
 
     let epoch_info = client.get_epoch_info().await?;
     let epoch = args.epoch.unwrap_or(epoch_info.epoch);
+    let last_epoch = epoch.saturating_sub(1);
     let program_id = validator_history::id();
 
     println!("Target epoch: {epoch}");
@@ -94,28 +113,34 @@ pub async fn run(args: CrankCopyIsBamConnected, rpc_url: String) -> anyhow::Resu
     let kobe_client = KobeApiClientBuilder::new()
         .base_url(args.kobe_api_base_url)
         .build();
-    let bam_validators = kobe_client
-        .get_bam_validators(epoch)
+    let validators = kobe_client
+        .get_validators(Some(last_epoch))
         .await
-        .map_err(|e| anyhow!("Failed to fetch BAM validators: {e}"))?
-        .bam_validators;
+        .map_err(|e| anyhow!("Failed to fetch validators: {e}"))?
+        .validators;
 
-    println!(
-        "Fetched {} BAM validators from Kobe API",
-        bam_validators.len()
-    );
+    println!("Fetched {} Validators from Kobe API", validators.len());
 
     // Pre-compute BAM pubkeys into a HashSet for O(1) lookup
-    let bam_pubkeys: HashSet<Pubkey> = bam_validators
+    let bam_vote_accounts: HashSet<Pubkey> = validators
         .iter()
-        .filter_map(|bam_v| Pubkey::from_str(&bam_v.vote_account).ok())
+        .filter_map(|bam_v| {
+            let vote_account = Pubkey::from_str(&bam_v.vote_account).ok()?;
+            let connection_rate = bam_v.bam_connection_rate?;
+
+            if connection_rate >= args.min_bam_connection_rate {
+                return Some(vote_account);
+            }
+
+            None
+        })
         .collect();
 
     // Build instructions for each validator
     let instructions: Vec<_> = vote_accounts_to_update
         .iter()
         .map(|vote_account| {
-            let is_bam_connected = bam_pubkeys.contains(vote_account);
+            let is_bam_connected = bam_vote_accounts.contains(vote_account);
 
             IsBamConnectedEntry::new(
                 *vote_account,


### PR DESCRIPTION
- Upload `is_bam_connected` once at 10% of epoch progress
- Fetch validators endpoint of kobe api, check bam_connection_rate
- If bam_connectioin_rate exceeds threshold (ex: 95%), keeper will consider this validator as `is_bam_connected: true`