### PR TITLE
Keeper: Remove unwrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1910,7 +1910,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3047,7 +3047,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4306,9 +4306,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "fastbloom",
@@ -4777,7 +4777,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4855,7 +4855,7 @@ dependencies = [
  "security-framework 3.5.1",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11555,7 +11555,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12611,7 +12611,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/keepers/stakenet-keeper/src/state/update_state.rs
+++ b/keepers/stakenet-keeper/src/state/update_state.rs
@@ -70,7 +70,7 @@ pub async fn pre_create_update(
             let account = maybe_sysvar_history
                 .value
                 .ok_or("SlotHistory sysvar not found at finalized commitment")?;
-            keeper_state.slot_history = deserialize::<SlotHistory>(&account.data).unwrap();
+            keeper_state.slot_history = deserialize::<SlotHistory>(&account.data)?;
         }
         Err(e) => {
             return Err(Box::new(e));

--- a/keepers/stakenet-keeper/src/state/update_state.rs
+++ b/keepers/stakenet-keeper/src/state/update_state.rs
@@ -67,7 +67,9 @@ pub async fn pre_create_update(
         .await
     {
         Ok(maybe_sysvar_history) => {
-            let account = maybe_sysvar_history.value.unwrap();
+            let account = maybe_sysvar_history
+                .value
+                .ok_or("SlotHistory sysvar not found at finalized commitment")?;
             keeper_state.slot_history = deserialize::<SlotHistory>(&account.data).unwrap();
         }
         Err(e) => {


### PR DESCRIPTION
### Problem

- Saw a panic on testnet
```bash
thread 'main' panicked at /usr/src/app/keepers/stakenet-keeper/src/state/update_state.rs:70:54:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

### Solution

- Do not kill the process, propagate an error