### PR TITLE
Steward: Fix Rebalance try_accounts stack frame exceeding SBF limit

### DIFF
--- a/programs/steward/src/instructions/rebalance.rs
+++ b/programs/steward/src/instructions/rebalance.rs
@@ -23,7 +23,10 @@ use crate::{
     errors::StewardError,
     events::{DecreaseComponents, RebalanceEvent, RebalanceTypeTag},
     maybe_transition,
-    stake_pool_utils::deserialize_stake_pool,
+    stake_pool_utils::{
+        deserialize_stake_pool, stake_pool_reserve_stake, stake_pool_validator_list,
+        stake_pool_withdraw_bump_seed,
+    },
     utils::{get_stake_pool_address, get_validator_stake_info_at_index, state_checks},
     Config, StewardStateAccount, StewardStateAccountV2, StewardStateEnum,
 };
@@ -62,21 +65,21 @@ pub struct Rebalance<'info> {
             STAKE_POOL_WITHDRAW_SEED
         ],
         seeds::program = spl_stake_pool::ID,
-        bump = deserialize_stake_pool(&stake_pool)?.stake_withdraw_bump_seed
+        bump = stake_pool_withdraw_bump_seed(&stake_pool)?
     )]
     pub withdraw_authority: AccountInfo<'info>,
 
     /// CHECK: passing through, checks are done by spl-stake-pool
     #[account(
         mut,
-        address = deserialize_stake_pool(&stake_pool)?.validator_list
+        address = stake_pool_validator_list(&stake_pool)?
     )]
     pub validator_list: AccountInfo<'info>,
 
     /// CHECK: passing through, checks are done by spl-stake-pool
     #[account(
         mut,
-        address = deserialize_stake_pool(&stake_pool)?.reserve_stake
+        address = stake_pool_reserve_stake(&stake_pool)?
     )]
     pub reserve_stake: AccountInfo<'info>,
 

--- a/programs/steward/src/stake_pool_utils.rs
+++ b/programs/steward/src/stake_pool_utils.rs
@@ -130,6 +130,21 @@ pub fn deserialize_stake_pool(
     )?)
 }
 
+#[inline(never)]
+pub fn stake_pool_withdraw_bump_seed(account_info: &AccountInfo) -> Result<u8> {
+    Ok(deserialize_stake_pool(account_info)?.stake_withdraw_bump_seed)
+}
+
+#[inline(never)]
+pub fn stake_pool_validator_list(account_info: &AccountInfo) -> Result<Pubkey> {
+    Ok(deserialize_stake_pool(account_info)?.validator_list)
+}
+
+#[inline(never)]
+pub fn stake_pool_reserve_stake(account_info: &AccountInfo) -> Result<Pubkey> {
+    Ok(deserialize_stake_pool(account_info)?.reserve_stake)
+}
+
 pub fn deserialize_validator_list(
     account_info: &AccountInfo,
 ) -> Result<spl_stake_pool::state::ValidatorList> {


### PR DESCRIPTION
## Problem

`Rebalance::try_accounts` (the anchor-generated account validation for the `Rebalance` instruction) has a 4,144-byte stack frame — 48 bytes over the SBF per-function limit of 4,096. Every build has been printing this as a non-fatal diagnostic:

```
Error: Function ...Rebalance...try_accounts... Stack offset of 4144 exceeded max offset of 4096 by 48 bytes ... may cause undefined behavior during execution.
```

With the current toolsuite (anza v3.0.8) the overflow happens to be harmless — codegen luck. Building the **unchanged master source** with newer platform-tools (v1.52, via the anza v3.1.9 toolsuite) shifts the stack layout so the same overflow corrupts a pointer, and `Rebalance` fails deterministically at runtime:

```
Program failed: Access violation in unknown section at address 0x10 of size 8
```

All 7 `steward::test_cycle::*` integration tests that reach `Rebalance` fail this way. This was discovered while attempting the solana-gossip upgrade (which forces a toolsuite bump for edition-2024 dependencies), but it's independent of that work: **any future toolchain upgrade of the program build pipeline produces a broken `Rebalance` until this is fixed.**

## Root cause

Three `#[account(...)]` constraints call `deserialize_stake_pool(&stake_pool)?.<field>`. The helper returns `StakePool` **by value**, so each call materializes the full struct (~600B) in `try_accounts`' own frame — by-value returns land in the caller's frame, so the helper being a separate function doesn't help.

## Fix

The SBF stack limit is per-function-frame, so the fix moves the temporaries into their own frames: three `#[inline(never)]` accessors in `stake_pool_utils.rs` that deserialize internally and return only the needed field (`u8`/`Pubkey`):

- `bump = deserialize_stake_pool(&stake_pool)?.stake_withdraw_bump_seed` → `bump = stake_pool_withdraw_bump_seed(&stake_pool)?`
- `address = ...validator_list` → `address = stake_pool_validator_list(&stake_pool)?`
- `address = ...reserve_stake` → `address = stake_pool_reserve_stake(&stake_pool)?`

Identical checks, identical error propagation, no behavior change. Two files, no IDL change, no Cargo.lock change.