### PR TITLE
Keeper: Reduce Loki noise by moving tick logs to debug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11233,7 +11233,7 @@ checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "stakenet-keeper"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anchor-lang",
  "bincode",

--- a/keepers/stakenet-keeper/Cargo.toml
+++ b/keepers/stakenet-keeper/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stakenet-keeper"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Script to keep validator history accounts up to date"
 

--- a/keepers/stakenet-keeper/src/main.rs
+++ b/keepers/stakenet-keeper/src/main.rs
@@ -157,7 +157,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
         // The fetch ( update ) functions fetch everything we need for the operations from the blockchain
         // Additionally, this function will update the keeper state. If update fails - it will skip the fire functions.
         if should_update(tick, &intervals) {
-            info!("Pre-fetching update data tick={tick}");
+            debug!("Pre-fetching update data tick={tick}");
             match pre_create_update(&keeper_config, &mut keeper_state).await {
                 Ok(_) => {
                     keeper_state.increment_update_run_for_epoch(KeeperOperations::PreCreateUpdate);
@@ -174,7 +174,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
             }
 
             if keeper_config.pay_for_new_accounts {
-                info!("Creating missing accounts tick={tick}");
+                debug!("Creating missing accounts tick={tick}");
                 match create_missing_accounts(&keeper_config, &keeper_state).await {
                     Ok(new_accounts_created) => {
                         keeper_state.increment_update_run_for_epoch(
@@ -210,7 +210,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
                 }
             }
 
-            info!("Post-fetching update data tick={tick}");
+            debug!("Post-fetching update data tick={tick}");
             match post_create_update(&keeper_config, &mut keeper_state).await {
                 Ok(_) => {
                     keeper_state.increment_update_run_for_epoch(KeeperOperations::PostCreateUpdate);
@@ -231,28 +231,28 @@ async fn run_keeper(keeper_config: KeeperConfig) {
 
         // VALIDATOR HISTORY
         if should_fire(tick, validator_history_interval) {
-            info!("Running operation operation=cluster_history");
+            debug!("Running operation operation=cluster_history");
             keeper_state.set_runs_errors_and_txs_for_epoch(
                 operations::cluster_history::fire(&keeper_config, &keeper_state).await,
             );
 
-            info!("Running operation operation=vote_account");
+            debug!("Running operation operation=vote_account");
             keeper_state.set_runs_errors_txs_and_flags_for_epoch(
                 operations::vote_account::fire(&keeper_config, &keeper_state).await,
             );
 
-            info!("Running operation operation=mev_commission");
+            debug!("Running operation operation=mev_commission");
             keeper_state.set_runs_errors_and_txs_for_epoch(
                 operations::mev_commission::fire(&keeper_config, &keeper_state).await,
             );
 
-            info!("Running operation operation=mev_earned");
+            debug!("Running operation operation=mev_earned");
             keeper_state.set_runs_errors_and_txs_for_epoch(
                 operations::mev_earned::fire(&keeper_config, &keeper_state).await,
             );
 
             if keeper_config.oracle_authority_keypair.is_some() {
-                info!("Running operation operation=stake_upload");
+                debug!("Running operation operation=stake_upload");
                 keeper_state.set_runs_errors_and_txs_for_epoch(
                     operations::stake_upload::fire(&keeper_config, &keeper_state).await,
                 );
@@ -261,19 +261,19 @@ async fn run_keeper(keeper_config: KeeperConfig) {
             if keeper_config.oracle_authority_keypair.is_some()
                 && keeper_config.gossip_entrypoints.is_some()
             {
-                info!("Running operation operation=gossip_upload");
+                debug!("Running operation operation=gossip_upload");
                 keeper_state.set_runs_errors_and_txs_for_epoch(
                     operations::gossip_upload::fire(&keeper_config, &keeper_state).await,
                 );
             }
 
-            info!("Running operation operation=priority_fee_commission");
+            debug!("Running operation operation=priority_fee_commission");
             keeper_state.set_runs_errors_and_txs_for_epoch(
                 operations::priority_fee_commission::fire(&keeper_config, &keeper_state).await,
             );
 
             if keeper_config.oracle_authority_keypair.is_some() {
-                info!("Running operation operation=copy_is_bam_connected");
+                debug!("Running operation operation=copy_is_bam_connected");
                 let copy_is_bam_connected_op =
                     CopyIsBamConnectedOperation::new(&keeper_config, &keeper_state);
                 keeper_state
@@ -287,7 +287,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
 
         // STEWARD
         if should_fire(tick, steward_interval) {
-            info!("Running operation operation=steward");
+            debug!("Running operation operation=steward");
             keeper_state.set_runs_errors_txs_and_flags_for_epoch(
                 operations::steward::fire(&keeper_config, &keeper_state).await,
             );
@@ -303,7 +303,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
                 .priority_fee_oracle_authority_keypair
                 .is_some()
         {
-            info!("Running operation operation=block_metadata");
+            debug!("Running operation operation=block_metadata");
             keeper_state.set_runs_errors_and_txs_for_epoch(
                 operations::block_metadata::operations::fire(&keeper_config, &keeper_state).await,
             );
@@ -323,7 +323,7 @@ async fn run_keeper(keeper_config: KeeperConfig) {
         }
 
         if should_emit(tick, &intervals) {
-            info!("Emitting keeper state metrics");
+            debug!("Emitting keeper state metrics");
             keeper_state.emit();
 
             KeeperOperations::emit(


### PR DESCRIPTION
## Motivation

- Very hard to debug the error, warnings, since the keeper emits many unnecessary logs

## Changes

- Reduce the level of log for tick information