### PR TITLE
SDK, Keeper: Fix `BlockhashNotFound` in compute-probing simulation

### DIFF
--- a/sdk/src/utils/transactions.rs
+++ b/sdk/src/utils/transactions.rs
@@ -96,11 +96,6 @@ async fn simulate_instruction(
         Hash::default(),
     );
 
-    // This simulation only exists to measure compute usage, so the blockhash is
-    // irrelevant. Ask the RPC to substitute its own recent blockhash instead of
-    // validating ours (`replace_recent_blockhash`), otherwise a simulating node
-    // that lags behind the node which served our blockhash rejects the tx with
-    // `BlockhashNotFound`.
     client
         .simulate_transaction_with_config(
             &test_tx,

--- a/sdk/src/utils/transactions.rs
+++ b/sdk/src/utils/transactions.rs
@@ -4,7 +4,7 @@ use std::vec;
 use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use log::*;
-use solana_client::rpc_config::RpcSendTransactionConfig;
+use solana_client::rpc_config::{RpcSendTransactionConfig, RpcSimulateTransactionConfig};
 use solana_client::rpc_response::{
     Response, RpcResult, RpcSimulateTransactionResult, RpcVoteAccountInfo,
 };
@@ -85,8 +85,6 @@ async fn simulate_instruction(
     priority_fee_in_microlamports: u64,
     max_cu_per_tx: u32,
 ) -> Result<Response<RpcSimulateTransactionResult>, ClientError> {
-    let latest_blockhash = get_latest_blockhash_with_retry(client).await?;
-
     let test_tx = Transaction::new_signed_with_payer(
         &[
             ComputeBudgetInstruction::set_compute_unit_limit(max_cu_per_tx),
@@ -95,10 +93,24 @@ async fn simulate_instruction(
         ],
         Some(&signer.pubkey()),
         &[signer],
-        latest_blockhash,
+        Hash::default(),
     );
 
-    client.simulate_transaction(&test_tx).await
+    // This simulation only exists to measure compute usage, so the blockhash is
+    // irrelevant. Ask the RPC to substitute its own recent blockhash instead of
+    // validating ours (`replace_recent_blockhash`), otherwise a simulating node
+    // that lags behind the node which served our blockhash rejects the tx with
+    // `BlockhashNotFound`.
+    client
+        .simulate_transaction_with_config(
+            &test_tx,
+            RpcSimulateTransactionConfig {
+                sig_verify: false,
+                replace_recent_blockhash: true,
+                ..RpcSimulateTransactionConfig::default()
+            },
+        )
+        .await
 }
 
 async fn simulate_instruction_with_retry(


### PR DESCRIPTION
## Problem

The keeper intermittently fails to submit instructions, logging:

```
ERROR stakenet_sdk::utils::transactions] Instruction simulation failed max_cu_per_tx=300000
  response=RpcSimulateTransactionResult { err: Some(BlockhashNotFound), ... }
datapoint: simulation-error error="Blockhash not found" instruction="... HistoryJTG... copy_vote_account ..."
```

These errors come from the **compute-probing simulation** in `find_ix_per_tx` (used by
`pack_instructions`), not from real transaction submission. When the simulation returns
an error, `pack_instructions` silently `continue`s and drops that instruction, so the
affected ixs (e.g. `copy_vote_account` for some validators) are never packed or sent.

## Root cause

`simulate_instruction` split the blockhash across two separate RPC calls:

1. fetch a `finalized` blockhash `H` via `get_latest_blockhash_with_retry`, then
2. call `client.simulate_transaction()` with the default config
   (`replace_recent_blockhash: false`), which asks a node to **validate** `H`.

This only works when both calls hit the same, caught-up node. Behind a load-balanced /
multi-backend RPC endpoint (or when a replica lags), the simulating node may not yet have
`H` in its blockhash queue and rejects with `BlockhashNotFound`. The blockhash is
irrelevant here — this simulation exists only to measure compute units.

## Fix

Sign the probe tx with `Hash::default()` and pass `replace_recent_blockhash: true` so the
RPC substitutes its own recent blockhash. This removes the cross-call dependency entirely,
so node lag / LB routing can no longer cause `BlockhashNotFound` during simulation.