### PR TITLE
CLI: Add `view-stake-eta` to estimate when a validator receives stake

### DIFF
--- a/utils/steward-cli/README.md
+++ b/utils/steward-cli/README.md
@@ -105,7 +105,12 @@ cargo run -p steward-cli -- \
     --min-change-sol 5000
 ```
 
-The projection prints per-epoch movements, a per-validator rollup, and per-epoch totals.
+The projection prints per-epoch movements, a per-validator rollup, and per-epoch totals. The
+rollup separates **undirected** from **directed** balance, and that distinction matters when
+reading it: targets are measured against undirected stake only, so a validator holding directed
+stake shows a near-zero undirected figure and a full-target shortfall while actually holding
+several times the target. Those rows are flagged inline with the real total, so they are not
+mistaken for the pool's most underfunded validators.
 Because the unstake budget is cycle-scoped rather than rate-limited per epoch, the projection
 spends it as soon as a cycle opens; treat the per-cycle totals as reliable and the exact epoch
 within a cycle as indicative, since real timing depends on when cranks run.

--- a/utils/steward-cli/README.md
+++ b/utils/steward-cli/README.md
@@ -45,6 +45,14 @@ cargo run -p steward-cli -- \
 Estimates how many epochs until a validator receives stake, given current pool conditions.
 Answers "when should I expect stake?" for a validator that is already eligible.
 
+> **This does not guarantee stake.** The command reports what is firm (eligibility, target, rank,
+> queue position, remaining budget — all read from chain) alongside what is a projection of
+> current conditions. Deposit and withdrawal flow, validator performance, other operators'
+> commission changes, and the re-scoring at every cycle boundary are not predictable and are not
+> modelled. A figure 10 or 20 epochs out can differ substantially from what happens. The output
+> carries this caveat in both the human banner and the JSON `disclaimer` field — **if you share
+> this with validators, the caveat has to travel with it**, or a projection gets read as a promise.
+
 **[STAKE_ETA.md](./STAKE_ETA.md) documents the model this implements** — why arrival is a queue
 rather than a schedule, the exact inputs, the output schema, and the known limitations. Read it
 before changing the estimator.
@@ -111,9 +119,11 @@ reading it: targets are measured against undirected stake only, so a validator h
 stake shows a near-zero undirected figure and a full-target shortfall while actually holding
 several times the target. Those rows are flagged inline with the real total, so they are not
 mistaken for the pool's most underfunded validators.
+
 Because the unstake budget is cycle-scoped rather than rate-limited per epoch, the projection
 spends it as soon as a cycle opens; treat the per-cycle totals as reliable and the exact epoch
-within a cycle as indicative, since real timing depends on when cranks run.
+within a cycle as indicative, since real timing depends on when cranks run. Rows at or past the
+next cycle boundary are marked `(?)`, since the set is re-scored there.
 
 ### View State of Single Validator
 

--- a/utils/steward-cli/README.md
+++ b/utils/steward-cli/README.md
@@ -40,6 +40,76 @@ cargo run -p steward-cli -- \
     --steward-config jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv
 ```
 
+### View Stake ETA
+
+Estimates how many epochs until a validator receives stake, given current pool conditions.
+Answers "when should I expect stake?" for a validator that is already eligible.
+
+**[STAKE_ETA.md](./STAKE_ETA.md) documents the model this implements** — why arrival is a queue
+rather than a schedule, the exact inputs, the output schema, and the known limitations. Read it
+before changing the estimator.
+
+Omit `--vote-account` to print only the pool-level summary (TVL, delegation set size, target
+stake per validator, remaining churn budget, and the aggregate shortfall/supply picture).
+
+```bash
+cargo run -p steward-cli -- \
+    --json-rpc-url $(solana config get | grep "RPC URL" | awk '{print $3}') \
+    view-stake-eta \
+    --steward-config jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv \
+    --vote-account J1to1yufRnoWn81KYg1XkTWzmKjnYSnmE2VY8DGUJ9Qv
+```
+
+Increases are funded from the reserve in descending score order, so a validator's wait is
+driven by the cumulative shortfall of everyone ranked above it, and by how much rotation
+budget is left in the cycle (`scoring_unstake_cap_bps`, reset every
+`num_epochs_between_scoring` epochs).
+
+Net new deposits are the one input that is not on-chain. By default the estimate assumes
+none, which gives the pessimistic bound. Supply an optimistic per-epoch rate to widen the
+band:
+
+```bash
+cargo run -p steward-cli -- \
+    --json-rpc-url $(solana config get | grep "RPC URL" | awk '{print $3}') \
+    view-stake-eta \
+    --steward-config jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv \
+    --vote-account J1to1yufRnoWn81KYg1XkTWzmKjnYSnmE2VY8DGUJ9Qv \
+    --deposit-rate-sol 20000 \
+    --print-json
+```
+
+`limiting_factor` in the output names the actual blocker — `at_target`, `not_in_set`,
+`awaiting_cooldown`, `scoring_churn_budget_exhausted`, `queue_position`, `next_rebalance`,
+or `reserve_empty` — and is more actionable than the epoch count alone.
+
+Estimates have cycle granularity, and any estimate crossing a cycle boundary assumes the
+delegation set and its size are unchanged; both are re-derived at each boundary.
+
+`--top N` additionally lists the N validators furthest over target and the N largest holders
+of directed stake. Directed stake is excluded from algorithmic targets, so it is not
+reducible by the scoring-unstake path — this shows how much of the pool's apparent excess is
+actually directed.
+
+`--schedule-epochs N` projects stake movement forward N epochs, replaying the program's
+ordering rules: decreases lowest-raw-score first against the cycle unstake budgets, increases
+highest-score first out of the reserve, with a one-epoch cooldown between the two. Use
+`--min-change-sol X` to drop the long tail of trivial adjustments (default 1000 SOL).
+
+```bash
+cargo run -p steward-cli -- \
+    --json-rpc-url $(solana config get | grep "RPC URL" | awk '{print $3}') \
+    view-stake-eta \
+    --steward-config jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv \
+    --schedule-epochs 24 \
+    --min-change-sol 5000
+```
+
+The projection prints per-epoch movements, a per-validator rollup, and per-epoch totals.
+Because the unstake budget is cycle-scoped rather than rate-limited per epoch, the projection
+spends it as soon as a cycle opens; treat the per-cycle totals as reliable and the exact epoch
+within a cycle as indicative, since real timing depends on when cranks run.
+
 ### View State of Single Validator
 
 Displays state of a single Validator.

--- a/utils/steward-cli/STAKE_ETA.md
+++ b/utils/steward-cli/STAKE_ETA.md
@@ -6,6 +6,27 @@ from mainnet at epoch 1012.*
 
 ---
 
+## 0. What this can and cannot tell a validator
+
+**It cannot promise stake.** The distinction to hold onto, and the one that has to survive into
+any validator-facing wording:
+
+| Confidence | What |
+| :- | :- |
+| **Firm** | Eligibility, the 1/N target, rank, SOL queued ahead, remaining churn budget and its reset epoch. Read directly from on-chain state. |
+| **Reasonable** | What a validator would receive next epoch given the reserve exactly as it stands. |
+| **Speculative** | Anything past the next cycle boundary. The set is re-scored, N changes, every target moves with TVL. |
+| **Not modelled** | Deposit and withdrawal rate, changes in this or other validators' performance and commissions, instant-unstake events elsewhere. |
+
+A projection 10 or 20 epochs out can differ substantially from what actually happens. The
+implementation emits this caveat on every invocation — as a banner at the top *and* bottom of the
+human output, and as a `disclaimer` array plus `speculative_beyond_epoch` in the JSON, so a
+consumer cannot render the numbers without it. Schedule rows at or past the re-scoring boundary
+are marked `(?)`.
+
+The intended default answer to "when do I get stake" is therefore *"here is what is certain, here
+is what it depends on, and here is why no one can give you a date"* — not a number.
+
 ## 1. Purpose and scope
 
 Validators can already see **whether** they are eligible on the StakeNet steward page. The

--- a/utils/steward-cli/STAKE_ETA.md
+++ b/utils/steward-cli/STAKE_ETA.md
@@ -1,0 +1,322 @@
+# StakeNet "When Do I Get Stake?" — ETA Endpoint Spec
+
+*Design spec for a validator-facing stake-arrival estimator. Derived entirely from public
+on-chain state; no Steward program changes required. Every figure below is live CLI output
+from mainnet at epoch 1012.*
+
+---
+
+## 1. Purpose and scope
+
+Validators can already see **whether** they are eligible on the StakeNet steward page. The
+unanswered question is **"in how many epochs should I expect stake, given today's
+conditions?"** — and, for validators already in the set but below target, "why am I not at my
+full share yet?"
+
+In scope:
+
+- Epochs-to-first-stake and epochs-to-target for a given vote account.
+- Current TVL and the resulting target stake per eligible validator.
+- The validator's position in the funding queue and how much SOL must be funded ahead of them.
+- Remaining churn budget for the current cycle and the epoch it resets.
+
+Out of scope (already served by the existing UI):
+
+- Eligibility pass/fail and which filter is failing.
+- Score and rank display.
+
+## 2. Why this is a queue, not a schedule
+
+Stake does not arrive on a timetable. It arrives when two independent things line up:
+**supply exists in the reserve**, and **the validator is next in line for it**.
+
+Increases are funded exclusively from the stake pool's reserve stake account. In each epoch's
+rebalance step, the Steward walks validators in **descending score order**, giving each one
+the smaller of (its shortfall to target) and (whatever reserve is left). A validator at rank
+300 receives nothing until every under-target validator ranked above it has been topped up.
+
+Supply reaches the reserve from exactly three places:
+
+1. **Net new JitoSOL deposits** — exogenous, driven by demand for JitoSOL.
+2. **Stake unstaked from over-target validators**, which is what funds rotation. Hard-capped
+   at 7.5% of the undirected pool per 10-epoch cycle (`scoring_unstake_cap_bps = 750`).
+3. **Stake recovered from instant-unstaked or removed validators**, under their own caps.
+
+Unstaked lamports take roughly one epoch to cool down before they are spendable, so supply
+created in epoch N is deliverable in epoch N+1 at the earliest.
+
+The consequence that matters: **when the scoring-unstake budget for a cycle is spent,
+rotation stops until the cycle resets**, regardless of how far below target anyone is. This
+is the single biggest driver of "I'm eligible but nothing is happening," and it is fully
+observable on-chain.
+
+## 3. The model
+
+### 3.1 Definitions
+
+```
+N              = number of validators in the delegation set (delegation denominator)
+undirected     = stake pool total_lamports - directed_stake_meta.total_staked_lamports()
+pool_adj       = undirected - (minimum_delegation + stake_rent) * n_validators
+target         = pool_adj / N                       # equal share, same for every member
+cur(v)         = active stake of v, minus base lamports, minus directed stake
+short(v)       = max(0, target - cur(v))            # v's shortfall
+rank(v)        = index of v in sorted_score_indices, restricted to set members
+ahead(v)       = sum of short(u) for all u in set with rank(u) < rank(v)
+need(v)        = ahead(v) + short(v)                # cumulative funding to reach v's target
+```
+
+**The directed-stake subtraction is not optional.** `instructions/rebalance.rs:259` passes
+`total_pool_lamports - directed_stake_meta.total_staked_lamports()` into `rebalance`, so
+targets are computed on the undirected pool. Divide the gross pool by N instead and every
+target is overstated by `directed_total / N` — currently 1,218 SOL per
+validator — which aggregates to a phantom pool-wide shortfall equal to the entire directed
+balance. This spec's earlier draft made exactly that error.
+
+Because the consequence is a silently wrong answer rather than an error, the implementation treats an unreadable `DirectedStakeMeta` as fatal rather than defaulting to zero directed stake. `--assume-no-directed-stake` overrides this, and is only correct for a deployment that genuinely has none.
+
+### 3.2 Supply per cycle
+
+```
+scoring_cap        = pool_adj * 750 / 10_000
+scoring_remaining  = scoring_cap - scoring_unstake_total     # both on-chain
+unstakeable        = sum of excess over target across all validators
+                     + all stake held by validators no longer in the set
+
+this_cycle_supply  = min(scoring_remaining, unstakeable) + usable_reserve
+                     + deposits_remaining_this_cycle
+future_cycle_supply= min(scoring_cap, unstakeable_then)      + deposits_per_cycle
+```
+
+Note that `scoring_cap` is recomputed from the *current* undirected pool every time
+`rebalance` runs, while `scoring_unstake_total` accumulates across the cycle. If directed
+stake grows mid-cycle the cap shrinks beneath the running total, so `scoring_remaining` can
+saturate at zero with the total slightly exceeding the cap — which is the case right now
+(717,368 used against a 717,230 cap). Clamp, don't assert.
+
+### 3.3 The estimate
+
+Walk cycles forward, drawing down `need(v)` against the supply available in each, and report
+the epoch at which cumulative supply first covers it:
+
+```
+remaining = need(v)
+remaining -= min(this_cycle_supply, remaining)
+if remaining <= 0:
+    eta = 1 epoch          # floored by cooldown
+else:
+    cycles = ceil(remaining / future_cycle_supply)
+    eta    = epochs_until_reset + (cycles - 1) * num_epochs_between_scoring
+```
+
+`deposits_per_epoch` is the only input not readable from a single account fetch. Derive it
+from a trailing average of pool `total_lamports` deltas — the keeper already emits pool TVL
+per epoch, so this is a query against existing metrics, not new instrumentation. Report the
+ETA as a band across a low / high deposit assumption rather than a single number.
+
+## 4. Inputs
+
+| Source | Fields used | Purpose |
+| :- | :- | :- |
+| Steward config<br>`jitoVjT9jRUyeXHzvCwzPgHj7yWNRhLcUoXtes4wtjv` | `scoring_unstake_cap_bps`, `instant_unstake_cap_bps`, `stake_deposit_unstake_cap_bps`, `num_epochs_between_scoring`, `num_delegation_validators`, `undirected_stake_ceiling_lamports` | Caps, cycle length, reserve ceiling |
+| Steward state<br>`9BAmGVLGxzqct6bkgjWmKSv3BFB6iKYXNBQp8GWG1LDY` | `next_cycle_epoch`, `delegations[]`, `sorted_score_indices[]`, `sorted_raw_score_indices[]`, `scores[]`, `instant_unstake`, the three unstake totals, `num_pool_validators` | Set membership, N, funding rank, unstake rank, budget consumption, reset date |
+| JitoSOL stake pool<br>`Jito4APyf642JPZPx3hGc6WWJ8zPKtRbRs4P815Awbb` | `total_lamports`, `reserve_stake` | TVL and immediate reserve availability |
+| Validator list<br>`3R3nGZpQs2aZo5FDQvd2MUQ6R7KhAPainds6uT6uE2mn` | `active_stake_lamports`, `transient_stake_lamports`, `vote_account_address` per entry | Per-validator current stake, in-flight detection |
+| DirectedStakeMeta | `total_staked_lamports()` and `directed_stake_lamports[]` | Subtract directed stake from **both** the pool and each balance |
+| Keeper metrics / TVL history | pool `total_lamports` per epoch | Trailing deposit rate for the ETA band |
+
+The four accounts are a single `getMultipleAccounts` call. The whole computation runs in well
+under a second and needs no indexer.
+
+## 5. Output schema
+
+```json
+{
+  "vote_account": "AuGwcQWqWuNbnrkgERSp8VN6kZeJiM4AZuLMrwbkzg9m",
+  "as_of_epoch": 1012,
+  "in_delegation_set": true,
+  "pool": {
+    "tvl_sol": 9943825,
+    "undirected_pool_sol": 9563065,
+    "delegation_set_size": 312,
+    "set_size_cap": 400,
+    "capacity_constrained": false,
+    "target_stake_sol": 30651
+  },
+  "position": {
+    "rank": 272,
+    "of": 312,
+    "current_stake_sol": 278,
+    "shortfall_sol": 30373,
+    "sol_ahead_in_queue": 24677
+  },
+  "budget": {
+    "scoring_churn_cap_sol": 717230,
+    "scoring_churn_used_sol": 717368,
+    "scoring_churn_remaining_sol": 0,
+    "pct_consumed": 100.0,
+    "resets_at_epoch": 1020
+  },
+  "eta": {
+    "first_stake": {
+      "low_epochs": 1,
+      "high_epochs": 1
+    },
+    "full_target": {
+      "low_epochs": 1,
+      "high_epochs": 1
+    },
+    "limiting_factor": "next_rebalance",
+    "confidence": "medium"
+  }
+}
+```
+
+`limiting_factor` is the field that does the most work for the validator. It should be one of
+a small enumerated set, each mapping to a plain-language explanation:
+
+| `limiting_factor` | What the validator is told |
+| :- | :- |
+| `at_target` | "You are at your full share. Nothing further is owed." |
+| `next_rebalance` | "Undelegated stake is available and nobody is ahead of you; expect stake at the next rebalance." |
+| `queue_position` | "N SOL must be funded to higher-ranked validators before you. Improving your score moves you up." |
+| `scoring_churn_budget_exhausted` | "Rotation for this cycle is used up. Budgets reset at epoch X." |
+| `awaiting_cooldown` | "Stake has been unstaked for you and is cooling down; expect it next epoch." |
+| `reserve_empty` | "There is no undelegated stake in the pool right now; arrival depends on new deposits." |
+| `not_in_set` | "You are not in the current delegation set; the next selection is at epoch X." |
+
+## 6. Worked example — mainnet at epoch 1012
+
+| Quantity | Value |
+| :- | :- |
+| Pool TVL | 9,943,825 SOL |
+| Undirected pool (the target denominator) | 9,563,065 SOL |
+| Directed stake | 380,068 SOL across 2 validators |
+| Validators in pool / in set (N) | 691 / 312 |
+| Set size cap | 400 — not binding |
+| Target per set member | **30,651 SOL** |
+| Under target | 88 validators, 1,067,702 SOL of shortfall |
+| Over target | 223 validators |
+| Reducible excess in total | 1,005,199 SOL |
+| Held by validators no longer in the set | 160,493 SOL across 68 validators |
+| Scoring churn budget | 717,230 SOL per cycle |
+| Scoring churn consumed | 717,368 SOL — 100%, exhausted |
+| Fundable rest of this cycle | 62,187 SOL (reserve only) |
+| Reserve stake balance | 62,189 SOL |
+| Next cycle | epoch 1020 (8 epochs out) |
+
+The shortfall is **strongly bimodal**, which is why a single pool-wide answer is useless:
+
+| Cohort | Count | Needs | Typical shortfall |
+| :- | :- | :- | :- |
+| Existing members topping up | 54 | 27,474 SOL | 95 SOL (median) |
+| New entrants with ~no stake | 34 | 1,040,228 SOL | 30,651 SOL (full target) |
+
+The 34 new entrants occupy ranks 272–311 — the bottom of the set — so they
+sit behind the entire top-up cohort **and** behind each other. Their individual answers differ
+by an order of magnitude:
+
+| Rank | Cumulative funding needed to reach them | Funded in | Epochs from 1012 |
+| :- | :- | :- | :- |
+| 272 (first new entrant) | 55,050 SOL | epoch 1013, from the current reserve | 1 |
+| 284 | 391,306 SOL | epoch 1021, after the cycle-1020 unstake cools down | 9 |
+| 298 | 729,249 SOL | epoch 1021, at the margin of that tranche | 9 |
+| 311 (last) | 1,067,702 SOL | epoch 1031, needs the cycle-1030 budget too | 19 |
+
+Meanwhile a rank-50 member short by ~95 SOL is answered completely differently: near the front
+of the queue, needs a trivial amount, and is topped up in the first epoch the reserve holds
+anything. Both facts are worth saying.
+
+### 6.1 The reconciliation invariant
+
+With directed stake correctly excluded from both sides, the accounting closes on reserve and
+in-flight stake alone:
+
+```
+total_shortfall - total_excess = reserve + transient
+
+verified against mainnet at epoch 1012:
+  1,067,702 - 1,005,199 = 62,502 SOL
+  reserve 62,189 + transient ~300      = ~62,489 SOL   OK
+```
+
+Assert this in tests. Asserting instead that shortfall equals reducible supply will fail, and
+asserting that the difference includes directed stake means the target denominator is wrong.
+
+Projected forward, every member of the delegation set reaches its 30,651 SOL
+share, with only a few hundred SOL of sub-minimum-delegation dust outstanding. **There is no
+structural gap and no permanently unfundable cohort.**
+
+## 7. Presentation guidance
+
+- **Lead with the limiting factor, not the number.** "Rotation budget for this cycle is spent;
+  resets epoch 1020" is more actionable and more honest than "9 epochs."
+- **Always show a range.** A point estimate will be treated as a promise and will be wrong the
+  moment deposit flow changes.
+- **Show the queue explicitly.** "24,677 SOL must be funded
+  ahead of you" makes the mechanism legible and makes the wait feel like arithmetic rather than
+  a black box.
+- **Say that rank is improvable.** Funding order is by score, so lowering inflation or MEV
+  commission moves a validator up the queue — not merely into the set. This is the one lever
+  validators actually control, and today's data puts it at ~18 epochs of difference between the
+  top and bottom of the new-entrant cohort.
+- **Distinguish first-stake from full-target.** A validator may receive a partial delegation
+  several epochs before reaching 1/N.
+
+## 8. Known limitations
+
+- **Deposit flow is the dominant uncertainty.** In a strong inflow week, new entrants are
+  funded from deposits without touching the churn budget at all, and the ETA collapses. The
+  band must be wide enough to express this.
+- **Instant-unstake events are unpredictable** and cut both ways: a commission rug elsewhere
+  frees supply early, but also consumes budget.
+- **The set can change under you at a cycle boundary.** A projection past `next_cycle_epoch`
+  assumes the set and N are stable; both move. Flag any ETA crossing a cycle boundary as
+  re-derived at that boundary.
+- **Within a cycle the unstake budget is not rate-limited per epoch**, so a projection spends
+  it as soon as the cycle opens. Real movement inside a cycle depends on when cranks run.
+  Treat per-cycle totals as reliable and the exact epoch within a cycle as indicative.
+- **Directed staking competes for the same reserve** on a per-epoch clock and is modelled here
+  only by subtracting directed lamports from the pool and from each balance.
+- **Cranker liveness** is assumed. If rebalance instructions are not cranked for every
+  validator in an epoch, some validators are simply skipped.
+- **Sub-minimum-delegation deltas never move**, so a validator within a hair of target may
+  never formally reach it. Treat "within minimum delegation of target" as at-target.
+
+## 9. Implementation
+
+**Shipped:** `steward-cli view-stake-eta` implements this model.
+
+```bash
+# per-validator ETA
+steward-cli view-stake-eta --steward-config <cfg> --vote-account <pubkey>
+
+# pool-wide, with the over-target and directed-stake listings
+steward-cli view-stake-eta --steward-config <cfg> --top 12
+
+# forward projection of stake movement, filtering out trivial changes
+steward-cli view-stake-eta --steward-config <cfg> --schedule-epochs 24 --min-change-sol 5000
+```
+
+Remaining work:
+
+1. **Covered.** 28 tests in `view_stake_eta.rs`, of which four drive the real
+   `StewardStateV2::rebalance` and assert the program's own increase/decrease amounts match this
+   model — including that a validator's own directed stake does not count toward its target, and
+   that the projection's first epoch reproduces the program instruction-for-instruction. The
+   rest cover rank derivation, directed/base netting, the pool aggregation, and the projection's
+   cycle-boundary reset, cooldown lag, convergence and filtering.
+
+   Verified by mutation rather than by coverage alone. Each of these faults, injected
+   deliberately, fails at least one test: dropping the directed subtraction (5 tests), deriving
+   rank from index order instead of score order (2), removing the one-epoch cooldown (2),
+   never resetting the cycle budget (1), and ignoring the minimum-delegation floor when
+   queueing (1).
+2. Have the keeper emit the aggregate fields once per epoch (TVL, undirected pool, N, target,
+   budget consumed, total shortfall, size of the new-entrant cohort). That gives the trailing
+   deposit rate for free and makes the pool-level story chartable.
+3. Expose per-validator ETA on the steward page next to the existing eligibility display, led
+   by `limiting_factor`.
+
+Nothing here requires a program upgrade or a governance change. Every input is already
+on-chain and public today.

--- a/utils/steward-cli/src/commands/command_args.rs
+++ b/utils/steward-cli/src/commands/command_args.rs
@@ -346,6 +346,7 @@ pub enum Commands {
     ViewConfig(ViewConfig),
     ViewPriorityFeeConfig(ViewPriorityFeeConfig),
     ViewNextIndexToRemove(ViewNextIndexToRemove),
+    ViewStakeEta(ViewStakeEta),
     ViewBlacklist(ViewBlacklist),
     ViewDirectedStakeTickets(ViewDirectedStakeTickets),
     ViewDirectedStakeTicket(ViewDirectedStakeTicket),
@@ -441,6 +442,46 @@ pub struct ViewConfig {
 pub struct ViewPriorityFeeConfig {
     #[command(flatten)]
     pub view_parameters: ViewParameters,
+}
+
+#[derive(Parser)]
+#[command(
+    about = "Estimate how many epochs until a validator receives stake, given current pool conditions"
+)]
+pub struct ViewStakeEta {
+    #[command(flatten)]
+    pub view_parameters: ViewParameters,
+
+    /// Vote account to estimate for. Omit to print only the pool-level summary.
+    #[arg(long)]
+    pub vote_account: Option<Pubkey>,
+
+    /// Optimistic assumption for net new deposits per epoch, in SOL, used for the
+    /// low end of the ETA band. Defaults to 0, i.e. rotation-only.
+    #[arg(long, default_value = "0")]
+    pub deposit_rate_sol: f64,
+
+    /// Also list the N validators furthest over target, and the N largest holders of
+    /// directed stake, to show how much of the pool's excess is directed rather than
+    /// algorithmically reducible. 0 disables the listing.
+    #[arg(long, default_value = "0")]
+    pub top: usize,
+
+    /// Project stake movement forward this many epochs, producing a per-epoch schedule of
+    /// expected increases and decreases. 0 disables the projection.
+    #[arg(long, default_value = "0")]
+    pub schedule_epochs: u64,
+
+    /// Ignore validators whose total stake change due is below this many SOL, to filter out
+    /// the long tail of trivial adjustments.
+    #[arg(long, default_value = "1000")]
+    pub min_change_sol: f64,
+
+    /// Proceed even if the DirectedStakeMeta account cannot be read, assuming zero directed
+    /// stake. Only correct for a deployment that genuinely has no directed staking — otherwise
+    /// every target comes out overstated.
+    #[arg(long, default_value = "false")]
+    pub assume_no_directed_stake: bool,
 }
 
 #[derive(Parser)]

--- a/utils/steward-cli/src/commands/info/mod.rs
+++ b/utils/steward-cli/src/commands/info/mod.rs
@@ -7,4 +7,5 @@ pub mod view_directed_stake_tickets;
 pub mod view_directed_stake_whitelist;
 pub mod view_next_index_to_remove;
 pub mod view_priority_fee_config;
+pub mod view_stake_eta;
 pub mod view_state;

--- a/utils/steward-cli/src/commands/info/view_stake_eta.rs
+++ b/utils/steward-cli/src/commands/info/view_stake_eta.rs
@@ -1,0 +1,2288 @@
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use jito_steward::{
+    constants::BASIS_POINTS_MAX, utils::get_target_lamports, Config, DirectedStakeMeta,
+    StewardStateV2,
+};
+use serde::{Deserialize, Serialize};
+use solana_client::nonblocking::rpc_client::RpcClient;
+use solana_sdk::{native_token::lamports_to_sol, pubkey::Pubkey, stake::state::StakeStateV2};
+use spl_stake_pool::state::ValidatorStakeInfo;
+use stakenet_sdk::utils::accounts::{get_all_steward_accounts, get_directed_stake_meta};
+
+use crate::commands::command_args::ViewStakeEta;
+
+/// Why a validator is not yet at its target share. Mirrors the enum in the
+/// validator-facing spec so the UI can map each variant to plain language.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
+#[serde(rename_all = "snake_case")]
+pub enum LimitingFactor {
+    /// Already at (or within one minimum delegation of) the target share
+    AtTarget,
+    /// Not in the current delegation set; nothing is owed until the next scoring event
+    NotInSet,
+    /// Stake is already in flight for this validator and lands next epoch
+    AwaitingCooldown,
+    /// The scoring churn budget for this cycle is spent, so rotation has stopped
+    ScoringChurnBudgetExhausted,
+    /// Higher-ranked validators must be funded first
+    QueuePosition,
+    /// Supply is available and nobody is ahead; expect stake at the next rebalance
+    NextRebalance,
+    /// Nothing undelegated is available; arrival depends on new deposits
+    ReserveEmpty,
+}
+
+impl LimitingFactor {
+    /// Plain-language explanation, suitable for showing to a validator operator
+    pub fn explain(&self, resets_at_epoch: u64, sol_ahead: f64) -> String {
+        match self {
+            Self::AtTarget => "You are at your full share. Nothing further is owed.".to_string(),
+            Self::NotInSet => format!(
+                "You are not in the current delegation set. The next selection is at epoch {resets_at_epoch}."
+            ),
+            Self::AwaitingCooldown => {
+                "Stake is cooling down for you and should land next epoch.".to_string()
+            }
+            Self::ScoringChurnBudgetExhausted => format!(
+                "Rotation for this cycle is used up. Budgets reset at epoch {resets_at_epoch}."
+            ),
+            Self::QueuePosition => format!(
+                "{sol_ahead:.0} SOL must be funded to higher-ranked validators before you. Improving your score moves you up."
+            ),
+            Self::NextRebalance => {
+                "Undelegated stake is available and nobody is ahead of you; expect stake at the next rebalance."
+                    .to_string()
+            }
+            Self::ReserveEmpty => {
+                "There is no undelegated stake in the pool right now; arrival depends on new deposits."
+                    .to_string()
+            }
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PoolSummary {
+    pub tvl_sol: f64,
+    /// Pool lamports available for delegation, after per-validator rent and minimum delegation
+    pub delegatable_sol: f64,
+    pub delegation_set_size: u32,
+    pub set_size_cap: u32,
+    pub capacity_constrained: bool,
+    pub target_stake_sol: f64,
+    pub reserve_sol: f64,
+    pub validators_in_pool: usize,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BudgetSummary {
+    pub scoring_churn_cap_sol: f64,
+    pub scoring_churn_used_sol: f64,
+    pub scoring_churn_remaining_sol: f64,
+    pub pct_consumed: f64,
+    pub instant_unstake_remaining_sol: f64,
+    pub stake_deposit_unstake_remaining_sol: f64,
+    pub resets_at_epoch: u64,
+    pub epochs_until_reset: u64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct SupplySummary {
+    /// Stake sitting above target, plus everything held by validators no longer in the set
+    pub unstakeable_sol: f64,
+    /// Total shortfall across every under-target set member
+    pub total_shortfall_sol: f64,
+    pub validators_under_target: usize,
+    pub validators_over_target: usize,
+    /// Set members holding effectively no stake — these need a full target each
+    pub new_entrants: usize,
+    pub new_entrant_demand_sol: f64,
+    /// What rotation can still fund before the cycle resets
+    pub fundable_this_cycle_sol: f64,
+    pub fundable_per_future_cycle_sol: f64,
+    /// Directed stake across the whole pool. Excluded from algorithmic targets, so it is not
+    /// reducible by the scoring-unstake path.
+    pub directed_total_sol: f64,
+    pub validators_with_directed_stake: usize,
+}
+
+/// One line of the over-target / directed-stake listings
+#[derive(Serialize, Deserialize, Debug)]
+pub struct ValidatorLine {
+    pub vote_account: String,
+    pub rank: Option<usize>,
+    pub in_delegation_set: bool,
+    /// Full active stake as the stake pool sees it
+    pub active_sol: f64,
+    pub directed_sol: f64,
+    /// What the algorithm actually measures against target
+    pub undirected_sol: f64,
+    pub target_sol: f64,
+    /// Undirected stake above target — the only part the scoring-unstake path can remove
+    pub excess_sol: f64,
+    pub marked_instant_unstake: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct QueuePosition {
+    pub rank: usize,
+    pub of: usize,
+    pub current_stake_sol: f64,
+    pub directed_stake_sol: f64,
+    pub shortfall_sol: f64,
+    pub sol_ahead_in_queue: f64,
+    pub transient_sol: f64,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EtaBand {
+    pub low_epochs: Option<u64>,
+    pub high_epochs: Option<u64>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Eta {
+    pub first_stake: EtaBand,
+    pub full_target: EtaBand,
+    pub limiting_factor: LimitingFactor,
+    pub explanation: String,
+    pub confidence: String,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct StakeEtaOutput {
+    pub vote_account: Option<String>,
+    pub as_of_epoch: u64,
+    pub in_delegation_set: bool,
+    pub pool: PoolSummary,
+    pub budget: BudgetSummary,
+    pub supply: SupplySummary,
+    pub position: Option<QueuePosition>,
+    pub eta: Option<Eta>,
+    /// Per-epoch deposit assumptions used for the low/high band, in SOL
+    pub deposit_rate_assumption_sol: [f64; 2],
+    /// Populated when --top is set
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub most_over_target: Vec<ValidatorLine>,
+    /// Populated when --top is set
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub largest_directed_holders: Vec<ValidatorLine>,
+    /// Populated when --schedule-epochs is set
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub schedule: Option<Schedule>,
+}
+
+/// One validator's position relative to its target
+struct Row {
+    vote_account: Pubkey,
+    in_set: bool,
+    rank: Option<usize>,
+    /// Full active stake, as the stake pool reports it
+    active: u64,
+    /// Undirected active stake, net of base lamports — what targets are measured against
+    current: u64,
+    directed: u64,
+    transient: u64,
+    target: u64,
+    marked_instant_unstake: bool,
+    /// Position in sorted_raw_score_indices. Decreases are served lowest-raw-score first,
+    /// so this drives unstake order, independent of `rank`.
+    raw_rank: Option<usize>,
+    /// Delegation denominator, i.e. N. Authoritative for set size.
+    denominator: u32,
+}
+
+impl Row {
+    fn to_line(&self) -> ValidatorLine {
+        ValidatorLine {
+            vote_account: self.vote_account.to_string(),
+            rank: self.rank,
+            in_delegation_set: self.in_set,
+            active_sol: lamports_to_sol(self.active),
+            directed_sol: lamports_to_sol(self.directed),
+            undirected_sol: lamports_to_sol(self.current),
+            target_sol: lamports_to_sol(self.target),
+            excess_sol: lamports_to_sol(self.excess()),
+            marked_instant_unstake: self.marked_instant_unstake,
+        }
+    }
+}
+
+impl Row {
+    fn shortfall(&self) -> u64 {
+        self.target.saturating_sub(self.current)
+    }
+
+    fn excess(&self) -> u64 {
+        self.current.saturating_sub(self.target)
+    }
+}
+
+/// Builds the per-validator table, sorted so that queue position can be read off directly.
+fn build_rows(
+    state: &StewardStateV2,
+    validators: &[ValidatorStakeInfo],
+    directed_stake_meta: Option<&DirectedStakeMeta>,
+    delegatable_lamports: u64,
+    base_lamport_balance: u64,
+) -> Result<Vec<Row>> {
+    let num_pool_validators = state.num_pool_validators as usize;
+
+    // Rank is the position in sorted_score_indices, restricted to set members, so it matches
+    // the order `increase_stake_calculation` walks when handing out reserve lamports.
+    let mut rank_of_index = vec![None; num_pool_validators];
+    let mut next_rank = 0usize;
+    for &sorted_index in state.sorted_score_indices[..num_pool_validators].iter() {
+        let index = sorted_index as usize;
+        if index >= num_pool_validators {
+            continue;
+        }
+        if state.delegations[index].numerator > 0 {
+            rank_of_index[index] = Some(next_rank);
+            next_rank += 1;
+        }
+    }
+
+    // Decreases walk sorted_raw_score_indices in reverse, i.e. lowest raw score unstaked
+    // first, and cover every pool validator rather than only set members.
+    let mut raw_rank_of_index = vec![None; num_pool_validators];
+    for (position, &sorted_index) in state.sorted_raw_score_indices[..num_pool_validators]
+        .iter()
+        .enumerate()
+    {
+        let index = sorted_index as usize;
+        if index < num_pool_validators {
+            raw_rank_of_index[index] = Some(position);
+        }
+    }
+
+    let mut rows = Vec::with_capacity(num_pool_validators);
+    for (index, validator) in validators.iter().enumerate().take(num_pool_validators) {
+        let active = u64::from(validator.active_stake_lamports);
+        let transient = u64::from(validator.transient_stake_lamports);
+        let directed = directed_stake_meta
+            .map(|meta| meta.directed_stake_lamports[index])
+            .unwrap_or(0);
+
+        // Targets are computed against undirected lamports, and the validator list includes
+        // base lamports in active_stake_lamports.
+        let current = active
+            .saturating_sub(directed)
+            .saturating_sub(base_lamport_balance);
+
+        let delegation = &state.delegations[index];
+        let target = get_target_lamports(delegation, delegatable_lamports)
+            .map_err(|e| anyhow!("failed to compute target lamports: {e:?}"))?;
+
+        rows.push(Row {
+            vote_account: validator.vote_account_address,
+            in_set: delegation.numerator > 0,
+            rank: rank_of_index[index],
+            active,
+            current,
+            directed,
+            transient,
+            target,
+            marked_instant_unstake: state.instant_unstake.get(index).unwrap_or(false),
+            raw_rank: raw_rank_of_index[index],
+            denominator: delegation.denominator,
+        });
+    }
+
+    Ok(rows)
+}
+
+/// Pool lamports that algorithmic targets divide.
+///
+/// Mirrors the program exactly: `instructions/rebalance.rs:259` hands `rebalance` the pool
+/// **net of directed stake**, and `StewardStateV2::rebalance` then subtracts base lamports for
+/// every validator. Dividing the gross pool by N instead overstates every target by
+/// `directed_total / N`, which aggregates into a phantom pool-wide shortfall equal to the
+/// entire directed balance.
+fn delegatable_pool_lamports(
+    total_lamports: u64,
+    directed_total: u64,
+    base_lamport_balance: u64,
+    n_validators: u64,
+) -> u64 {
+    total_lamports
+        .saturating_sub(directed_total)
+        .saturating_sub(base_lamport_balance.saturating_mul(n_validators))
+}
+
+/// Pool-level demand and supply, derived purely from the per-validator rows so it can be
+/// tested without RPC.
+#[derive(Debug, PartialEq, Eq)]
+struct Aggregates {
+    /// Delegation set size, taken from the delegation denominator rather than by recounting
+    /// members, since the denominator is what the program actually divides by.
+    n: u32,
+    target_stake: u64,
+    /// Indices into `rows` of under-target set members, in the order the program funds them
+    /// (descending score).
+    under: Vec<usize>,
+    total_shortfall: u64,
+    over_target_count: usize,
+    /// Stake above target, plus everything still held by validators that fell out of the set.
+    unstakeable: u64,
+    /// Set members holding effectively nothing — each needs close to a full target.
+    new_entrants: usize,
+    new_entrant_demand: u64,
+}
+
+fn aggregate(rows: &[Row], minimum_delegation: u64) -> Aggregates {
+    let first_member = rows.iter().find(|r| r.in_set);
+    let n = first_member.map(|r| r.denominator).unwrap_or(0);
+    let target_stake = first_member.map(|r| r.target).unwrap_or(0);
+
+    let mut under: Vec<usize> = rows
+        .iter()
+        .enumerate()
+        .filter(|(_, r)| r.in_set && r.shortfall() > minimum_delegation)
+        .map(|(i, _)| i)
+        .collect();
+    under.sort_by_key(|&i| rows[i].rank.unwrap_or(usize::MAX));
+
+    let total_shortfall = under.iter().map(|&i| rows[i].shortfall()).sum();
+    let over_target_count = rows
+        .iter()
+        .filter(|r| r.in_set && r.excess() > minimum_delegation)
+        .count();
+    // For an out-of-set row `excess()` already equals `current`, since `build_rows` gives a
+    // zero target to any validator with a zero delegation numerator. The branch is kept
+    // explicit so this stays correct if that ever changes.
+    let unstakeable = rows
+        .iter()
+        .map(|r| if r.in_set { r.excess() } else { r.current })
+        .sum();
+
+    // "Effectively nothing" is within 10% of a full target's worth of shortfall.
+    let entrant_threshold = target_stake.saturating_mul(9) / 10;
+    let entrants: Vec<usize> = under
+        .iter()
+        .copied()
+        .filter(|&i| rows[i].shortfall() > entrant_threshold)
+        .collect();
+    let new_entrant_demand = entrants.iter().map(|&i| rows[i].shortfall()).sum();
+
+    Aggregates {
+        n,
+        target_stake,
+        under,
+        total_shortfall,
+        over_target_count,
+        unstakeable,
+        new_entrants: entrants.len(),
+        new_entrant_demand,
+    }
+}
+
+fn bps_of(lamports: u64, bps: u32) -> u64 {
+    ((lamports as u128) * (bps as u128) / (BASIS_POINTS_MAX as u128)) as u64
+}
+
+/// A single projected stake movement for one validator in one epoch
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ScheduledChange {
+    pub epoch: u64,
+    pub vote_account: String,
+    pub rank: Option<usize>,
+    /// Positive for a delegation, negative for an unstake, in SOL
+    pub change_sol: f64,
+    /// Projected undirected balance after this movement
+    pub balance_after_sol: f64,
+    pub target_sol: f64,
+    pub direction: String,
+}
+
+/// Per-validator rollup of everything projected over the horizon
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ScheduleSummaryRow {
+    pub vote_account: String,
+    pub rank: Option<usize>,
+    pub in_delegation_set: bool,
+    pub direction: String,
+    pub current_sol: f64,
+    pub target_sol: f64,
+    /// Total movement still due to reach target, regardless of horizon
+    pub total_due_sol: f64,
+    /// How much of that the projection actually delivers inside the horizon
+    pub projected_sol: f64,
+    pub first_epoch: Option<u64>,
+    pub last_epoch: Option<u64>,
+    /// True when the horizon ends before the validator reaches target
+    pub incomplete: bool,
+}
+
+/// Aggregate movement in a single projected epoch
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct EpochTotals {
+    pub epoch: u64,
+    pub increased_sol: f64,
+    pub decreased_sol: f64,
+    pub validators_increased: usize,
+    pub validators_decreased: usize,
+    pub reserve_at_start_sol: f64,
+    pub scoring_budget_remaining_sol: f64,
+    /// True when this epoch begins a new cycle, at which point budgets reset and the
+    /// delegation set is re-scored
+    pub cycle_boundary: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Schedule {
+    pub horizon_epochs: u64,
+    pub min_change_sol: f64,
+    pub deposit_rate_sol_per_epoch: f64,
+    pub changes: Vec<ScheduledChange>,
+    pub per_validator: Vec<ScheduleSummaryRow>,
+    pub per_epoch: Vec<EpochTotals>,
+    pub notes: Vec<String>,
+}
+
+/// Mutable simulation state for one validator
+struct SimRow {
+    vote_account: String,
+    rank: Option<usize>,
+    raw_rank: Option<usize>,
+    in_set: bool,
+    balance: u64,
+    target: u64,
+    marked_instant_unstake: bool,
+    /// Stake in flight. The program skips validators with transient stake, so a validator
+    /// touched in one epoch is not touched again in the next.
+    transient: u64,
+}
+
+/// Projects stake movement epoch by epoch, replaying the program's ordering rules:
+/// decreases lowest-raw-score first against the cycle unstake budgets, increases
+/// highest-score first out of the reserve, with a one-epoch cooldown between the two.
+#[allow(clippy::too_many_arguments)]
+fn project_schedule(
+    rows: &[Row],
+    current_epoch: u64,
+    next_cycle_epoch: u64,
+    cycle_length: u64,
+    horizon: u64,
+    min_change: u64,
+    minimum_delegation: u64,
+    scoring_cap: u64,
+    instant_cap: u64,
+    scoring_used: u64,
+    instant_used: u64,
+    reserve_start: u64,
+    deposit_per_epoch: u64,
+) -> Schedule {
+    let mut sim: Vec<SimRow> = rows
+        .iter()
+        .map(|r| SimRow {
+            vote_account: r.vote_account.to_string(),
+            rank: r.rank,
+            raw_rank: r.raw_rank,
+            in_set: r.in_set,
+            balance: r.current,
+            // A validator marked for instant unstake has an effective target of zero, which
+            // is what `decrease_stake_calculation` uses.
+            target: if r.marked_instant_unstake {
+                0
+            } else {
+                r.target
+            },
+            marked_instant_unstake: r.marked_instant_unstake,
+            transient: r.transient,
+        })
+        .collect();
+
+    // Original shortfall/excess, for the "total due" column.
+    let total_due: Vec<i128> = sim
+        .iter()
+        .map(|s| s.target as i128 - s.balance as i128)
+        .collect();
+
+    // Funding order: descending score. Unstake order: ascending raw score.
+    let mut increase_order: Vec<usize> = (0..sim.len()).collect();
+    increase_order.sort_by_key(|&i| sim[i].rank.unwrap_or(usize::MAX));
+    let mut decrease_order: Vec<usize> = (0..sim.len()).collect();
+    decrease_order.sort_by_key(|&i| sim[i].raw_rank.unwrap_or(usize::MAX));
+    decrease_order.reverse();
+
+    let mut scoring_remaining = scoring_cap.saturating_sub(scoring_used);
+    let mut instant_remaining = instant_cap.saturating_sub(instant_used);
+    let mut reserve = reserve_start;
+    // Lamports unstaked this epoch, which become spendable next epoch.
+    let mut cooling: u64 = 0;
+
+    let mut changes: Vec<ScheduledChange> = Vec::new();
+    let mut per_epoch: Vec<EpochTotals> = Vec::new();
+    let mut first_epoch: Vec<Option<u64>> = vec![None; sim.len()];
+    let mut last_epoch: Vec<Option<u64>> = vec![None; sim.len()];
+    let mut projected: Vec<i128> = vec![0; sim.len()];
+
+    for step in 1..=horizon {
+        let epoch = current_epoch + step;
+        let cycle_boundary =
+            epoch >= next_cycle_epoch && (epoch - next_cycle_epoch) % cycle_length == 0;
+        if cycle_boundary {
+            scoring_remaining = scoring_cap;
+            instant_remaining = instant_cap;
+        }
+
+        // Last epoch's unstakes have cooled down; deposits arrive.
+        reserve = reserve
+            .saturating_add(cooling)
+            .saturating_add(deposit_per_epoch);
+        cooling = 0;
+
+        let reserve_at_start = reserve;
+        let scoring_at_start = scoring_remaining;
+        let mut increased = 0u64;
+        let mut decreased = 0u64;
+        let mut n_inc = 0usize;
+        let mut n_dec = 0usize;
+
+        // Clear in-flight stake from the previous epoch before deciding this epoch's moves.
+        let touched_last: Vec<bool> = sim.iter().map(|s| s.transient > 0).collect();
+        for s in sim.iter_mut() {
+            s.transient = 0;
+        }
+
+        // ---- Decreases: lowest raw score first, against the cycle budgets ----
+        for &i in decrease_order.iter() {
+            if touched_last[i] {
+                continue;
+            }
+            let s = &sim[i];
+            if s.balance <= s.target {
+                continue;
+            }
+            let excess = s.balance - s.target;
+            let budget = if s.marked_instant_unstake {
+                &mut instant_remaining
+            } else {
+                &mut scoring_remaining
+            };
+            if *budget <= minimum_delegation {
+                continue;
+            }
+            let amount = excess.min(*budget);
+            if amount <= minimum_delegation {
+                continue;
+            }
+            *budget -= amount;
+            let s = &mut sim[i];
+            s.balance -= amount;
+            s.transient = amount;
+            cooling += amount;
+            decreased += amount;
+            n_dec += 1;
+            projected[i] -= amount as i128;
+            first_epoch[i] = first_epoch[i].or(Some(epoch));
+            last_epoch[i] = Some(epoch);
+            changes.push(ScheduledChange {
+                epoch,
+                vote_account: s.vote_account.clone(),
+                rank: s.rank,
+                change_sol: -lamports_to_sol(amount),
+                balance_after_sol: lamports_to_sol(s.balance),
+                target_sol: lamports_to_sol(s.target),
+                direction: if s.marked_instant_unstake {
+                    "instant-unstake".to_string()
+                } else {
+                    "decrease".to_string()
+                },
+            });
+        }
+
+        // ---- Increases: highest score first, out of the reserve ----
+        for &i in increase_order.iter() {
+            if reserve <= minimum_delegation {
+                break;
+            }
+            if touched_last[i] || sim[i].transient > 0 {
+                continue;
+            }
+            let s = &sim[i];
+            if !s.in_set || s.balance >= s.target {
+                continue;
+            }
+            let shortfall = s.target - s.balance;
+            let amount = shortfall.min(reserve);
+            if amount <= minimum_delegation {
+                continue;
+            }
+            reserve -= amount;
+            let s = &mut sim[i];
+            s.balance += amount;
+            s.transient = amount;
+            increased += amount;
+            n_inc += 1;
+            projected[i] += amount as i128;
+            first_epoch[i] = first_epoch[i].or(Some(epoch));
+            last_epoch[i] = Some(epoch);
+            changes.push(ScheduledChange {
+                epoch,
+                vote_account: s.vote_account.clone(),
+                rank: s.rank,
+                change_sol: lamports_to_sol(amount),
+                balance_after_sol: lamports_to_sol(s.balance),
+                target_sol: lamports_to_sol(s.target),
+                direction: "increase".to_string(),
+            });
+        }
+
+        per_epoch.push(EpochTotals {
+            epoch,
+            increased_sol: lamports_to_sol(increased),
+            decreased_sol: lamports_to_sol(decreased),
+            validators_increased: n_inc,
+            validators_decreased: n_dec,
+            reserve_at_start_sol: lamports_to_sol(reserve_at_start),
+            scoring_budget_remaining_sol: lamports_to_sol(scoring_at_start),
+            cycle_boundary,
+        });
+    }
+
+    // Keep only validators whose total movement clears the noise threshold.
+    let mut per_validator: Vec<ScheduleSummaryRow> = (0..sim.len())
+        .filter(|&i| {
+            total_due[i].unsigned_abs() as u64 >= min_change
+                || projected[i].unsigned_abs() as u64 >= min_change
+        })
+        .map(|i| {
+            let s = &sim[i];
+            ScheduleSummaryRow {
+                vote_account: s.vote_account.clone(),
+                rank: s.rank,
+                in_delegation_set: s.in_set,
+                direction: if total_due[i] > 0 {
+                    "increase".to_string()
+                } else if s.marked_instant_unstake {
+                    "instant-unstake".to_string()
+                } else {
+                    "decrease".to_string()
+                },
+                current_sol: lamports_to_sol(rows[i].current),
+                target_sol: lamports_to_sol(s.target),
+                total_due_sol: total_due[i] as f64 / 1e9,
+                projected_sol: projected[i] as f64 / 1e9,
+                first_epoch: first_epoch[i],
+                last_epoch: last_epoch[i],
+                incomplete: projected[i].unsigned_abs() < total_due[i].unsigned_abs(),
+            }
+        })
+        .collect();
+    per_validator.sort_by(|a, b| {
+        b.total_due_sol
+            .abs()
+            .partial_cmp(&a.total_due_sol.abs())
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+
+    // Drop the individual movements for validators we filtered out.
+    let kept: std::collections::HashSet<&str> = per_validator
+        .iter()
+        .map(|r| r.vote_account.as_str())
+        .collect();
+    let changes = changes
+        .iter()
+        .filter(|c| kept.contains(c.vote_account.as_str()))
+        .cloned()
+        .collect();
+
+    Schedule {
+        horizon_epochs: horizon,
+        min_change_sol: lamports_to_sol(min_change),
+        deposit_rate_sol_per_epoch: lamports_to_sol(deposit_per_epoch),
+        changes,
+        per_validator,
+        per_epoch,
+        notes: vec![
+            "Targets, the delegation set and N are held fixed across the horizon. At each cycle boundary the program re-scores and both can change, so movements past the first boundary are indicative only.".to_string(),
+            "Unstaked lamports are modelled as cooling down for one epoch before becoming spendable, and a validator touched in one epoch is skipped in the next, matching the program's transient-stake check.".to_string(),
+            "Stake-deposit unstaking is folded into the scoring budget, since distinguishing deposit-driven excess needs per-validator internal balances.".to_string(),
+            "Directed stake is excluded throughout; balances shown are undirected.".to_string(),
+        ],
+    }
+}
+
+/// Walks cycles forward, drawing `need` down against per-cycle supply, and returns the
+/// number of epochs from `current_epoch` until it is covered.
+fn epochs_until_funded(
+    need: u64,
+    fundable_this_cycle: u64,
+    fundable_per_cycle: u64,
+    epochs_until_reset: u64,
+    cycle_length: u64,
+) -> Option<u64> {
+    if need == 0 {
+        return Some(0);
+    }
+    if need <= fundable_this_cycle {
+        // Supply already exists inside this cycle, so the only remaining wait is the one
+        // epoch it takes unstaked lamports to cool down and be re-delegated.
+        return Some(1);
+    }
+    if fundable_per_cycle == 0 {
+        return None;
+    }
+    let remaining = need.saturating_sub(fundable_this_cycle);
+    // Number of whole future cycles required to cover the remainder.
+    let cycles = remaining.div_ceil(fundable_per_cycle);
+    Some(epochs_until_reset + (cycles.saturating_sub(1)) * cycle_length)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn classify(
+    row: Option<&Row>,
+    minimum_delegation: u64,
+    scoring_remaining: u64,
+    reserve_available: u64,
+    sol_ahead: u64,
+) -> LimitingFactor {
+    let Some(row) = row else {
+        return LimitingFactor::NotInSet;
+    };
+    if !row.in_set {
+        return LimitingFactor::NotInSet;
+    }
+    if row.shortfall() <= minimum_delegation {
+        return LimitingFactor::AtTarget;
+    }
+    if row.transient > 0 {
+        return LimitingFactor::AwaitingCooldown;
+    }
+    if scoring_remaining <= minimum_delegation && reserve_available <= minimum_delegation {
+        return LimitingFactor::ScoringChurnBudgetExhausted;
+    }
+    // Everything queued ahead already fits in the available reserve, so this validator is
+    // next in line rather than blocked.
+    if sol_ahead.saturating_add(minimum_delegation) <= reserve_available {
+        return LimitingFactor::NextRebalance;
+    }
+    if reserve_available <= minimum_delegation {
+        return LimitingFactor::ReserveEmpty;
+    }
+    LimitingFactor::QueuePosition
+}
+
+pub async fn command_view_stake_eta(
+    args: ViewStakeEta,
+    client: &Arc<RpcClient>,
+    program_id: Pubkey,
+) -> Result<()> {
+    let steward_config = args.view_parameters.steward_config;
+    let print_json = args.view_parameters.print_json;
+
+    let all_steward_accounts =
+        get_all_steward_accounts(client, &program_id, &steward_config).await?;
+    // Do NOT fall back to "no directed stake" on error. Targets are computed net of directed
+    // stake, so a failed fetch would silently overstate every target by directed_total / N and
+    // invent a pool-wide shortfall that does not exist.
+    let directed_stake_meta =
+        match get_directed_stake_meta(client.clone(), &steward_config, &program_id).await {
+            Ok(meta) => Some(meta),
+            Err(e) if args.assume_no_directed_stake => {
+                eprintln!(
+                    "warning: could not read DirectedStakeMeta ({e}); \
+                 continuing with --assume-no-directed-stake, targets assume zero directed stake"
+                );
+                None
+            }
+            Err(e) => {
+                return Err(anyhow!(
+                    "could not read DirectedStakeMeta: {e}\n\
+                 Targets are computed net of directed stake, so proceeding without it would \
+                 overstate every validator's target and report a shortfall that does not exist. \
+                 Pass --assume-no-directed-stake only if this deployment genuinely has none."
+                ))
+            }
+        };
+
+    let epoch_info = client.get_epoch_info().await?;
+    let current_epoch = epoch_info.epoch;
+
+    // Mirror the program's own arithmetic: `minimum_delegation(get_minimum_delegation())`
+    // plus rent for a stake account.
+    let stake_minimum_delegation = client.get_stake_minimum_delegation().await?;
+    let minimum_delegation = spl_stake_pool::minimum_delegation(stake_minimum_delegation);
+    let stake_rent = client
+        .get_minimum_balance_for_rent_exemption(std::mem::size_of::<StakeStateV2>())
+        .await?;
+    let base_lamport_balance = minimum_delegation
+        .checked_add(stake_rent)
+        .ok_or_else(|| anyhow!("overflow computing base lamport balance"))?;
+
+    let state_account = &all_steward_accounts.state_account;
+    let state = &state_account.state;
+    let config: &Config = &all_steward_accounts.config_account;
+    let params = &config.parameters;
+    let validator_list = &all_steward_accounts.validator_list_account;
+    let validators_in_pool = validator_list.as_ref().validators.len();
+
+    let total_lamports = all_steward_accounts.stake_pool_account.total_lamports;
+
+    // Targets are computed against the UNDIRECTED pool. `rebalance` is handed
+    // `total_pool_lamports - directed_stake_meta.total_staked_lamports()`
+    // (instructions/rebalance.rs:259) and subtracts base lamports from that, so directed
+    // stake must come out before dividing by N or every target is overstated.
+    let directed_total = directed_stake_meta
+        .as_ref()
+        .map(|meta| meta.total_staked_lamports())
+        .unwrap_or(0);
+    let undirected_pool_lamports = total_lamports.saturating_sub(directed_total);
+    let delegatable_lamports = delegatable_pool_lamports(
+        total_lamports,
+        directed_total,
+        base_lamport_balance,
+        validators_in_pool as u64,
+    );
+
+    let rows = build_rows(
+        state,
+        &validator_list.as_ref().validators,
+        directed_stake_meta.as_deref(),
+        delegatable_lamports,
+        base_lamport_balance,
+    )?;
+
+    let agg = aggregate(&rows, minimum_delegation);
+    let Aggregates {
+        n,
+        target_stake,
+        ref under,
+        total_shortfall,
+        over_target_count,
+        unstakeable,
+        new_entrants,
+        new_entrant_demand,
+    } = agg;
+    // Positions in `rows`, in the order the program funds them.
+    let under: Vec<&Row> = under.iter().map(|&i| &rows[i]).collect();
+
+    let scoring_cap = bps_of(delegatable_lamports, params.scoring_unstake_cap_bps);
+    let instant_cap = bps_of(delegatable_lamports, params.instant_unstake_cap_bps);
+    let deposit_cap = bps_of(delegatable_lamports, params.stake_deposit_unstake_cap_bps);
+    let scoring_remaining = scoring_cap.saturating_sub(state.scoring_unstake_total);
+
+    let epochs_until_reset = state.next_cycle_epoch.saturating_sub(current_epoch);
+    let cycle_length = params.num_epochs_between_scoring;
+
+    // Reserve must keep rent for every validator plus one transient account, matching
+    // the reservation made in `StewardStateV2::rebalance`.
+    let reserve_lamports = all_steward_accounts.reserve_stake_account.lamports;
+    // The program zeroes the usable reserve once undirected TVL reaches the ceiling, and
+    // otherwise caps it to the remaining headroom (instructions/rebalance.rs:262-271).
+    let stake_ceiling = params.undirected_stake_ceiling_lamports();
+    let capped_reserve = if undirected_pool_lamports >= stake_ceiling {
+        0
+    } else {
+        reserve_lamports.min(stake_ceiling.saturating_sub(undirected_pool_lamports))
+    };
+    let reserve_available =
+        capped_reserve.saturating_sub(stake_rent.saturating_mul(validators_in_pool as u64 + 1));
+
+    // Deposit flow is the one input that is not on-chain. Band it: the low case assumes no
+    // net deposits at all, the high case uses the operator-supplied rate.
+    let deposit_low = 0f64;
+    let deposit_high = args.deposit_rate_sol;
+    let deposit_high_lamports = (deposit_high * 1e9) as u64;
+
+    let rotation_this_cycle = scoring_remaining.min(unstakeable);
+    let fundable_this_cycle_low = rotation_this_cycle.saturating_add(reserve_available);
+    let fundable_this_cycle_high = fundable_this_cycle_low
+        .saturating_add(deposit_high_lamports.saturating_mul(epochs_until_reset));
+    let fundable_per_cycle_low = scoring_cap.min(unstakeable);
+    let fundable_per_cycle_high =
+        fundable_per_cycle_low.saturating_add(deposit_high_lamports.saturating_mul(cycle_length));
+
+    let pool = PoolSummary {
+        tvl_sol: lamports_to_sol(total_lamports),
+        delegatable_sol: lamports_to_sol(delegatable_lamports),
+        delegation_set_size: n,
+        set_size_cap: params.num_delegation_validators,
+        capacity_constrained: n >= params.num_delegation_validators,
+        target_stake_sol: lamports_to_sol(target_stake),
+        reserve_sol: lamports_to_sol(reserve_lamports),
+        validators_in_pool,
+    };
+
+    let budget = BudgetSummary {
+        scoring_churn_cap_sol: lamports_to_sol(scoring_cap),
+        scoring_churn_used_sol: lamports_to_sol(state.scoring_unstake_total),
+        scoring_churn_remaining_sol: lamports_to_sol(scoring_remaining),
+        pct_consumed: if scoring_cap == 0 {
+            0.
+        } else {
+            state.scoring_unstake_total as f64 / scoring_cap as f64 * 100.
+        },
+        instant_unstake_remaining_sol: lamports_to_sol(
+            instant_cap.saturating_sub(state.instant_unstake_total),
+        ),
+        stake_deposit_unstake_remaining_sol: lamports_to_sol(
+            deposit_cap.saturating_sub(state.stake_deposit_unstake_total),
+        ),
+        resets_at_epoch: state.next_cycle_epoch,
+        epochs_until_reset,
+    };
+
+    let supply = SupplySummary {
+        unstakeable_sol: lamports_to_sol(unstakeable),
+        total_shortfall_sol: lamports_to_sol(total_shortfall),
+        validators_under_target: under.len(),
+        validators_over_target: over_target_count,
+        new_entrants,
+        new_entrant_demand_sol: lamports_to_sol(new_entrant_demand),
+        fundable_this_cycle_sol: lamports_to_sol(fundable_this_cycle_low),
+        fundable_per_future_cycle_sol: lamports_to_sol(fundable_per_cycle_low),
+        directed_total_sol: lamports_to_sol(directed_total),
+        validators_with_directed_stake: rows.iter().filter(|r| r.directed > 0).count(),
+    };
+
+    // Listings that show how much of the pool's excess is directed, and therefore outside
+    // the reach of the scoring-unstake path.
+    let (most_over_target, largest_directed_holders) = if args.top == 0 {
+        (Vec::new(), Vec::new())
+    } else {
+        let mut by_excess: Vec<&Row> = rows.iter().filter(|r| r.excess() > 0).collect();
+        by_excess.sort_by_key(|r| std::cmp::Reverse(r.excess()));
+
+        let mut by_directed: Vec<&Row> = rows.iter().filter(|r| r.directed > 0).collect();
+        by_directed.sort_by_key(|r| std::cmp::Reverse(r.directed));
+
+        (
+            by_excess
+                .iter()
+                .take(args.top)
+                .map(|r| r.to_line())
+                .collect(),
+            by_directed
+                .iter()
+                .take(args.top)
+                .map(|r| r.to_line())
+                .collect(),
+        )
+    };
+
+    // Per-validator view, when a vote account was supplied.
+    let (position, eta, in_set) = match args.vote_account {
+        None => (None, None, false),
+        Some(vote_account) => {
+            let row = rows
+                .iter()
+                .find(|r| r.vote_account == vote_account)
+                .ok_or_else(|| {
+                    anyhow!("vote account {vote_account} is not in the stake pool validator list")
+                })?;
+
+            // Cumulative shortfall of every under-target member the program serves before this
+            // validator. Computed from rank rather than by position in `under`, so it stays
+            // correct when this validator is not itself under target.
+            let row_rank = row.rank.unwrap_or(usize::MAX);
+            let ahead: u64 = under
+                .iter()
+                .filter(|r| r.rank.unwrap_or(usize::MAX) < row_rank)
+                .map(|r| r.shortfall())
+                .sum();
+            let need_first = ahead.saturating_add(minimum_delegation);
+            let need_full = ahead.saturating_add(row.shortfall());
+
+            let limiting_factor = classify(
+                Some(row),
+                minimum_delegation,
+                scoring_remaining,
+                reserve_available,
+                ahead,
+            );
+
+            let eta = if limiting_factor == LimitingFactor::AtTarget {
+                Eta {
+                    first_stake: EtaBand {
+                        low_epochs: Some(0),
+                        high_epochs: Some(0),
+                    },
+                    full_target: EtaBand {
+                        low_epochs: Some(0),
+                        high_epochs: Some(0),
+                    },
+                    limiting_factor,
+                    explanation: limiting_factor
+                        .explain(state.next_cycle_epoch, lamports_to_sol(ahead)),
+                    confidence: "high".to_string(),
+                }
+            } else {
+                // The high-deposit assumption produces the optimistic (low epoch) bound.
+                let first_low = epochs_until_funded(
+                    need_first,
+                    fundable_this_cycle_high,
+                    fundable_per_cycle_high,
+                    epochs_until_reset,
+                    cycle_length,
+                );
+                let first_high = epochs_until_funded(
+                    need_first,
+                    fundable_this_cycle_low,
+                    fundable_per_cycle_low,
+                    epochs_until_reset,
+                    cycle_length,
+                );
+                let full_low = epochs_until_funded(
+                    need_full,
+                    fundable_this_cycle_high,
+                    fundable_per_cycle_high,
+                    epochs_until_reset,
+                    cycle_length,
+                );
+                let full_high = epochs_until_funded(
+                    need_full,
+                    fundable_this_cycle_low,
+                    fundable_per_cycle_low,
+                    epochs_until_reset,
+                    cycle_length,
+                );
+                Eta {
+                    first_stake: EtaBand {
+                        low_epochs: first_low,
+                        high_epochs: first_high,
+                    },
+                    full_target: EtaBand {
+                        low_epochs: full_low,
+                        high_epochs: full_high,
+                    },
+                    limiting_factor,
+                    explanation: limiting_factor
+                        .explain(state.next_cycle_epoch, lamports_to_sol(ahead)),
+                    // Anything that has to cross a cycle boundary is re-derived at that
+                    // boundary, because the set and N both move.
+                    confidence: if full_high.is_some_and(|e| e <= epochs_until_reset) {
+                        "medium".to_string()
+                    } else {
+                        "low".to_string()
+                    },
+                }
+            };
+
+            (
+                Some(QueuePosition {
+                    rank: row.rank.unwrap_or(0),
+                    of: n as usize,
+                    current_stake_sol: lamports_to_sol(row.current),
+                    directed_stake_sol: lamports_to_sol(row.directed),
+                    shortfall_sol: lamports_to_sol(row.shortfall()),
+                    // Nothing is owed to an at-target validator, so a queue figure would only
+                    // mislead.
+                    sol_ahead_in_queue: if limiting_factor == LimitingFactor::AtTarget {
+                        0.
+                    } else {
+                        lamports_to_sol(ahead)
+                    },
+                    transient_sol: lamports_to_sol(row.transient),
+                }),
+                Some(eta),
+                row.in_set,
+            )
+        }
+    };
+
+    let schedule = if args.schedule_epochs == 0 {
+        None
+    } else {
+        Some(project_schedule(
+            &rows,
+            current_epoch,
+            state.next_cycle_epoch,
+            cycle_length,
+            args.schedule_epochs,
+            (args.min_change_sol * 1e9) as u64,
+            minimum_delegation,
+            scoring_cap,
+            instant_cap,
+            state.scoring_unstake_total,
+            state.instant_unstake_total,
+            reserve_available,
+            deposit_high_lamports,
+        ))
+    };
+
+    let output = StakeEtaOutput {
+        vote_account: args.vote_account.map(|v| v.to_string()),
+        as_of_epoch: current_epoch,
+        in_delegation_set: in_set,
+        pool,
+        budget,
+        supply,
+        position,
+        eta,
+        deposit_rate_assumption_sol: [deposit_low, deposit_high],
+        most_over_target,
+        largest_directed_holders,
+        schedule,
+    };
+
+    if print_json {
+        println!("{}", serde_json::to_string_pretty(&output)?);
+    } else {
+        print_human(&output);
+    }
+
+    Ok(())
+}
+
+fn fmt_band(band: &EtaBand) -> String {
+    match (band.low_epochs, band.high_epochs) {
+        (Some(0), Some(0)) => "now".to_string(),
+        (Some(low), Some(high)) if low == high => format!("~{low} epochs"),
+        (Some(low), Some(high)) => format!("~{low}–{high} epochs"),
+        (Some(low), None) => format!("at least {low} epochs"),
+        _ => "unknown — no supply available under current conditions".to_string(),
+    }
+}
+
+fn print_lines(title: &str, lines: &[ValidatorLine]) {
+    println!("\n━━━ {title} ━━━");
+    println!(
+        "  {:<45} {:>5} {:>11} {:>11} {:>11} {:>11} {:>11}",
+        "vote account", "rank", "active", "directed", "undirected", "target", "excess"
+    );
+    for l in lines {
+        println!(
+            "  {:<45} {:>5} {:>11.0} {:>11.0} {:>11.0} {:>11.0} {:>11.0}{}{}",
+            l.vote_account,
+            l.rank.map(|r| r.to_string()).unwrap_or("—".to_string()),
+            l.active_sol,
+            l.directed_sol,
+            l.undirected_sol,
+            l.target_sol,
+            l.excess_sol,
+            if l.in_delegation_set {
+                ""
+            } else {
+                "  [not in set]"
+            },
+            if l.marked_instant_unstake {
+                "  [instant-unstake]"
+            } else {
+                ""
+            },
+        );
+    }
+}
+
+fn print_schedule(s: &Schedule) {
+    println!(
+        "\n━━━ Expected stake change by epoch — next {} epochs, changes ≥ {:.0} SOL ━━━",
+        s.horizon_epochs, s.min_change_sol
+    );
+    if s.per_validator.is_empty() {
+        println!("  No validator has a change of that size due.");
+        return;
+    }
+
+    println!(
+        "\n  {:<8} {:>5} {:<44} {:>12} {:>13} {:>12}",
+        "epoch", "rank", "vote account", "change", "balance after", "target"
+    );
+    let mut last_epoch = 0u64;
+    for c in &s.changes {
+        if c.epoch != last_epoch {
+            if last_epoch != 0 {
+                println!();
+            }
+            last_epoch = c.epoch;
+        }
+        println!(
+            "  {:<8} {:>5} {:<44} {:>+12.0} {:>13.0} {:>12.0}  {}",
+            c.epoch,
+            c.rank.map(|r| r.to_string()).unwrap_or("—".to_string()),
+            c.vote_account,
+            c.change_sol,
+            c.balance_after_sol,
+            c.target_sol,
+            c.direction,
+        );
+    }
+
+    println!("\n━━━ Per-validator rollup ━━━");
+    println!(
+        "  {:<44} {:>5} {:>11} {:>11} {:>11} {:>11} {:>7} {:>6}",
+        "vote account", "rank", "current", "target", "total due", "projected", "epochs", "done"
+    );
+    for r in &s.per_validator {
+        let epochs = match (r.first_epoch, r.last_epoch) {
+            (Some(f), Some(l)) if f == l => format!("{f}"),
+            (Some(f), Some(l)) => format!("{f}-{l}"),
+            _ => "none".to_string(),
+        };
+        println!(
+            "  {:<44} {:>5} {:>11.0} {:>11.0} {:>+11.0} {:>+11.0} {:>7} {:>6}{}",
+            r.vote_account,
+            r.rank.map(|x| x.to_string()).unwrap_or("—".to_string()),
+            r.current_sol,
+            r.target_sol,
+            r.total_due_sol,
+            r.projected_sol,
+            epochs,
+            if r.incomplete { "no" } else { "yes" },
+            if r.in_delegation_set {
+                ""
+            } else {
+                "  [not in set]"
+            },
+        );
+    }
+
+    println!("\n━━━ Per-epoch totals ━━━");
+    println!(
+        "  {:<8} {:>12} {:>12} {:>6} {:>6} {:>14} {:>14}",
+        "epoch", "increased", "decreased", "up", "down", "reserve start", "churn left"
+    );
+    for e in &s.per_epoch {
+        println!(
+            "  {:<8} {:>12.0} {:>12.0} {:>6} {:>6} {:>14.0} {:>14.0}{}",
+            e.epoch,
+            e.increased_sol,
+            e.decreased_sol,
+            e.validators_increased,
+            e.validators_decreased,
+            e.reserve_at_start_sol,
+            e.scoring_budget_remaining_sol,
+            if e.cycle_boundary {
+                "   ← new cycle, budgets reset & set re-scored"
+            } else {
+                ""
+            },
+        );
+    }
+
+    println!("\n  Assumptions:");
+    for n in &s.notes {
+        println!("    - {n}");
+    }
+}
+
+fn print_human(o: &StakeEtaOutput) {
+    println!("\n━━━ Pool (epoch {}) ━━━", o.as_of_epoch);
+    println!("  TVL:                    {:>14.0} SOL", o.pool.tvl_sol);
+    println!(
+        "  Delegatable:            {:>14.0} SOL",
+        o.pool.delegatable_sol
+    );
+    println!(
+        "  Delegation set:         {:>14} of {} cap{}",
+        o.pool.delegation_set_size,
+        o.pool.set_size_cap,
+        if o.pool.capacity_constrained {
+            "  (AT CAP — rank gates membership)"
+        } else {
+            "  (below cap — eligibility gates membership, not rank)"
+        }
+    );
+    println!(
+        "  Target per validator:   {:>14.0} SOL",
+        o.pool.target_stake_sol
+    );
+    println!("  Reserve:                {:>14.0} SOL", o.pool.reserve_sol);
+
+    println!("\n━━━ Churn budget (per cycle) ━━━");
+    println!(
+        "  Scoring:                {:>14.0} / {:.0} SOL used  ({:.1}%)",
+        o.budget.scoring_churn_used_sol, o.budget.scoring_churn_cap_sol, o.budget.pct_consumed
+    );
+    println!(
+        "  Scoring remaining:      {:>14.0} SOL",
+        o.budget.scoring_churn_remaining_sol
+    );
+    println!(
+        "  Instant remaining:      {:>14.0} SOL",
+        o.budget.instant_unstake_remaining_sol
+    );
+    println!(
+        "  Deposit remaining:      {:>14.0} SOL",
+        o.budget.stake_deposit_unstake_remaining_sol
+    );
+    println!(
+        "  Resets at epoch:        {:>14}  ({} epochs away)",
+        o.budget.resets_at_epoch, o.budget.epochs_until_reset
+    );
+
+    println!("\n━━━ Demand and supply ━━━");
+    println!(
+        "  Under target:           {:>14} validators, {:.0} SOL short",
+        o.supply.validators_under_target, o.supply.total_shortfall_sol
+    );
+    println!(
+        "    of which new entrants:{:>14} validators, {:.0} SOL",
+        o.supply.new_entrants, o.supply.new_entrant_demand_sol
+    );
+    println!(
+        "  Over target:            {:>14} validators",
+        o.supply.validators_over_target
+    );
+    println!(
+        "  Unstakeable supply:     {:>14.0} SOL",
+        o.supply.unstakeable_sol
+    );
+    println!(
+        "  Fundable this cycle:    {:>14.0} SOL",
+        o.supply.fundable_this_cycle_sol
+    );
+    println!(
+        "  Fundable per cycle:     {:>14.0} SOL",
+        o.supply.fundable_per_future_cycle_sol
+    );
+    println!(
+        "  Directed stake:         {:>14.0} SOL across {} validators  (excluded from targets)",
+        o.supply.directed_total_sol, o.supply.validators_with_directed_stake
+    );
+
+    if !o.most_over_target.is_empty() {
+        print_lines(
+            "Furthest over target (excess is undirected, so scoring-unstake can remove it)",
+            &o.most_over_target,
+        );
+    }
+    if !o.largest_directed_holders.is_empty() {
+        print_lines(
+            "Largest directed-stake holders (directed portion is NOT algorithmically reducible)",
+            &o.largest_directed_holders,
+        );
+    }
+
+    if let Some(sched) = &o.schedule {
+        print_schedule(sched);
+    }
+
+    if let (Some(p), Some(e)) = (&o.position, &o.eta) {
+        println!(
+            "\n━━━ {} ━━━",
+            o.vote_account.as_deref().unwrap_or("validator")
+        );
+        println!(
+            "  In delegation set:      {:>14}",
+            if o.in_delegation_set { "yes" } else { "no" }
+        );
+        println!("  Rank:                   {:>14} of {}", p.rank, p.of);
+        println!(
+            "  Current stake:          {:>14.0} SOL",
+            p.current_stake_sol
+        );
+        if p.directed_stake_sol > 0. {
+            println!(
+                "    (directed, excluded): {:>14.0} SOL",
+                p.directed_stake_sol
+            );
+        }
+        println!("  Shortfall to target:    {:>14.0} SOL", p.shortfall_sol);
+        println!(
+            "  SOL ahead in queue:     {:>14.0} SOL",
+            p.sol_ahead_in_queue
+        );
+        if p.transient_sol > 0. {
+            println!("  In flight:              {:>14.0} SOL", p.transient_sol);
+        }
+        println!("\n  First stake:  {}", fmt_band(&e.first_stake));
+        println!("  Full target:  {}", fmt_band(&e.full_target));
+        println!("  Why:          {}", e.explanation);
+        println!(
+            "  Confidence:   {}  (deposit assumption {:.0}–{:.0} SOL/epoch)",
+            e.confidence, o.deposit_rate_assumption_sol[0], o.deposit_rate_assumption_sol[1]
+        );
+        println!(
+            "\n  Note: estimates crossing epoch {} assume the set and N are unchanged; both are",
+            o.budget.resets_at_epoch
+        );
+        println!("  re-derived at each cycle boundary.");
+    }
+    println!();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use jito_steward::{
+        constants::{MAX_VALIDATORS, SORTED_INDEX_DEFAULT},
+        delegation::RebalanceType,
+        state::directed_stake::DirectedStakeTarget,
+        BitMask, Delegation, Parameters, StewardStateEnum,
+    };
+    use spl_stake_pool::{
+        big_vec::BigVec,
+        state::{PodStakeStatus, StakeStatus},
+    };
+
+    const SOL: u64 = 1_000_000_000;
+
+    /// Byte layout of `spl_stake_pool::state::ValidatorList`'s vec, so the program's `BigVec`
+    /// reader sees the same thing it sees on chain. Mirrors `tests/tests/steward/mod.rs`.
+    fn serialize_validator_list(validators: &[ValidatorStakeInfo]) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&(validators.len() as u32).to_le_bytes());
+        for v in validators {
+            data.extend_from_slice(&u64::from(v.active_stake_lamports).to_le_bytes());
+            data.extend_from_slice(&u64::from(v.transient_stake_lamports).to_le_bytes());
+            data.extend_from_slice(&u64::from(v.last_update_epoch).to_le_bytes());
+            data.extend_from_slice(&u64::from(v.transient_seed_suffix).to_le_bytes());
+            data.extend_from_slice(&u32::from(v.unused).to_le_bytes());
+            data.extend_from_slice(&u32::from(v.validator_seed_suffix).to_le_bytes());
+            // PodStakeStatus is a repr(transparent) wrapper around u8.
+            let status_byte = unsafe { *(&v.status as *const PodStakeStatus as *const u8) };
+            data.push(status_byte);
+            data.extend_from_slice(v.vote_account_address.as_ref());
+        }
+        data
+    }
+
+    /// A pool of `actives.len()` validators, all in the delegation set with an equal 1/N share,
+    /// scored highest-first in index order.
+    fn fixture(actives: &[u64]) -> (Box<StewardStateV2>, Vec<ValidatorStakeInfo>, Parameters) {
+        let n = actives.len();
+        let mut sorted = [SORTED_INDEX_DEFAULT; MAX_VALIDATORS];
+        let mut scores = [0u64; MAX_VALIDATORS];
+        let mut delegations = [Delegation::default(); MAX_VALIDATORS];
+        let mut balances = [0u64; MAX_VALIDATORS];
+        for i in 0..n {
+            sorted[i] = i as u16;
+            scores[i] = (n - i) as u64 * 1_000_000;
+            delegations[i] = Delegation::new(1, n as u32);
+            // Internal balance == actual, so no stake-deposit excess is inferred.
+            balances[i] = actives[i];
+        }
+
+        let state = Box::new(StewardStateV2 {
+            state_tag: StewardStateEnum::Rebalance,
+            validator_lamport_balances: balances,
+            scores,
+            sorted_score_indices: sorted,
+            raw_scores: scores,
+            sorted_raw_score_indices: sorted,
+            delegations,
+            instant_unstake: BitMask::default(),
+            progress: BitMask::default(),
+            validators_for_immediate_removal: BitMask::default(),
+            validators_to_remove: BitMask::default(),
+            start_computing_scores_slot: 0,
+            current_epoch: 100,
+            next_cycle_epoch: 110,
+            num_pool_validators: n as u64,
+            scoring_unstake_total: 0,
+            instant_unstake_total: 0,
+            stake_deposit_unstake_total: 0,
+            status_flags: 0,
+            validators_added: 0,
+            _padding0: [0; 2],
+        });
+
+        let validators: Vec<ValidatorStakeInfo> = actives
+            .iter()
+            .map(|a| ValidatorStakeInfo {
+                active_stake_lamports: (*a).into(),
+                transient_stake_lamports: 0.into(),
+                status: StakeStatus::Active.into(),
+                vote_account_address: Pubkey::new_unique(),
+                ..ValidatorStakeInfo::default()
+            })
+            .collect();
+
+        // Uncapped, so these tests isolate target arithmetic rather than budget rationing.
+        let params = Parameters {
+            scoring_unstake_cap_bps: 10_000,
+            instant_unstake_cap_bps: 10_000,
+            stake_deposit_unstake_cap_bps: 10_000,
+            ..Parameters::default()
+        };
+
+        (state, validators, params)
+    }
+
+    /// Directed stake recorded only pool-wide, via the targets array. Per-validator indices stay
+    /// at u64::MAX so no individual balance is adjusted — this isolates the denominator.
+    fn directed_pool_only(amount: u64) -> Box<DirectedStakeMeta> {
+        let mut meta = Box::new(DirectedStakeMeta::default());
+        meta.total_stake_targets = 1;
+        meta.targets[0] = DirectedStakeTarget {
+            total_staked_lamports: amount,
+            total_target_lamports: amount,
+            ..DirectedStakeTarget::default()
+        };
+        meta
+    }
+
+    /// Build the rows the way the command does, from a fixture.
+    fn rows_for(
+        state: &StewardStateV2,
+        validators: &[ValidatorStakeInfo],
+        meta: &DirectedStakeMeta,
+        total_pool: u64,
+        base: u64,
+    ) -> Vec<Row> {
+        let pool = delegatable_pool_lamports(
+            total_pool,
+            meta.total_staked_lamports(),
+            base,
+            validators.len() as u64,
+        );
+        build_rows(state, validators, Some(meta), pool, base).expect("build_rows")
+    }
+
+    // ---------------------------------------------------------------- build_rows
+
+    /// Rank must follow `sorted_score_indices` restricted to set members, since that is the
+    /// order `increase_stake_calculation` walks. Index order is deliberately NOT score order
+    /// here, so a test that confused the two would fail.
+    #[test]
+    fn build_rows_derives_rank_from_score_order_not_index_order() {
+        let actives = [100 * SOL, 200 * SOL, 300 * SOL, 400 * SOL];
+        let (mut state, validators, _) = fixture(&actives);
+        // Score order: v2 best, then v0, then v3, then v1.
+        state.sorted_score_indices[..4].copy_from_slice(&[2, 0, 3, 1]);
+        // Unstake order is independent: v1 worst-raw-score, so it is unstaked first.
+        state.sorted_raw_score_indices[..4].copy_from_slice(&[3, 0, 2, 1]);
+
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            4_000 * SOL,
+            0,
+        );
+
+        assert_eq!(rows[2].rank, Some(0));
+        assert_eq!(rows[0].rank, Some(1));
+        assert_eq!(rows[3].rank, Some(2));
+        assert_eq!(rows[1].rank, Some(3));
+
+        // raw_rank is the position in sorted_raw_score_indices, untouched by funding order.
+        assert_eq!(rows[3].raw_rank, Some(0));
+        assert_eq!(rows[1].raw_rank, Some(3));
+    }
+
+    /// A validator outside the delegation set has no rank, a zero target, and its whole balance
+    /// counts as reducible supply.
+    #[test]
+    fn build_rows_marks_validators_outside_the_set() {
+        let actives = [500 * SOL, 500 * SOL, 500 * SOL];
+        let (mut state, validators, _) = fixture(&actives);
+        // Drop v1 from the set.
+        state.delegations[1] = Delegation::new(0, 1);
+        state.sorted_score_indices[..3].copy_from_slice(&[0, 2, 1]);
+
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            1_500 * SOL,
+            0,
+        );
+
+        assert!(!rows[1].in_set);
+        assert_eq!(rows[1].rank, None);
+        assert_eq!(rows[1].target, 0);
+        assert_eq!(rows[1].excess(), 500 * SOL);
+        // Ranks skip the non-member entirely.
+        assert_eq!(rows[0].rank, Some(0));
+        assert_eq!(rows[2].rank, Some(1));
+    }
+
+    /// `current` is what targets are measured against: active stake minus directed minus base.
+    #[test]
+    fn build_rows_nets_directed_stake_and_base_lamports_out_of_current() {
+        let actives = [1_000 * SOL, 1_000 * SOL];
+        let base = 3_282_880u64;
+        let (state, validators, _) = fixture(&actives);
+
+        let mut meta = directed_pool_only(400 * SOL);
+        meta.directed_stake_lamports[0] = 400 * SOL;
+
+        let rows = rows_for(&state, &validators, &meta, 2_400 * SOL, base);
+
+        assert_eq!(rows[0].active, 1_000 * SOL);
+        assert_eq!(rows[0].directed, 400 * SOL);
+        assert_eq!(rows[0].current, 1_000 * SOL - 400 * SOL - base);
+        // v1 holds no directed stake, so only base comes off.
+        assert_eq!(rows[1].current, 1_000 * SOL - base);
+    }
+
+    // ---------------------------------------------------------------- aggregate
+
+    #[test]
+    fn aggregate_orders_the_funding_queue_by_rank_and_totals_correctly() {
+        let target = 1_000 * SOL;
+        let actives = [
+            1_500 * SOL, // over by 500
+            50 * SOL,    // under by 950 -> a "new entrant" (>90% of target)
+            990 * SOL,   // under by 10, below the minimum delegation -> ignored
+            600 * SOL,   // under by 400
+        ];
+        let (mut state, validators, _) = fixture(&actives);
+        // Funding order v3, v1, v0, v2 — deliberately not index order.
+        state.sorted_score_indices[..4].copy_from_slice(&[3, 1, 0, 2]);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            4_000 * SOL,
+            0,
+        );
+        assert_eq!(
+            rows[0].target, target,
+            "fixture should give a 1000 SOL target"
+        );
+
+        let agg = aggregate(&rows, 100 * SOL);
+
+        assert_eq!(agg.n, 4);
+        assert_eq!(agg.target_stake, target);
+        // v2's 10 SOL shortfall is under the minimum delegation, so it is not queued.
+        assert_eq!(agg.under, vec![3, 1]);
+        assert_eq!(agg.total_shortfall, 950 * SOL + 400 * SOL);
+        assert_eq!(agg.over_target_count, 1);
+        assert_eq!(agg.unstakeable, 500 * SOL);
+        // Only v1 is short by more than 90% of a target.
+        assert_eq!(agg.new_entrants, 1);
+        assert_eq!(agg.new_entrant_demand, 950 * SOL);
+    }
+
+    #[test]
+    fn aggregate_counts_out_of_set_balances_as_reducible_supply() {
+        let actives = [1_200 * SOL, 300 * SOL];
+        let (mut state, validators, _) = fixture(&actives);
+        state.delegations[1] = Delegation::new(0, 1);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            1_500 * SOL,
+            0,
+        );
+        // Target is 1500/2 = 750 for the remaining member; v0 is 450 over.
+        let agg = aggregate(&rows, SOL);
+        assert_eq!(agg.unstakeable, 450 * SOL + 300 * SOL);
+    }
+
+    #[test]
+    fn aggregate_on_an_empty_set_is_zeroed_rather_than_panicking() {
+        let actives = [500 * SOL];
+        let (mut state, validators, _) = fixture(&actives);
+        state.delegations[0] = Delegation::new(0, 1);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            500 * SOL,
+            0,
+        );
+        let agg = aggregate(&rows, SOL);
+        assert_eq!(agg.n, 0);
+        assert_eq!(agg.target_stake, 0);
+        assert!(agg.under.is_empty());
+    }
+
+    // ---------------------------------------------------------------- project_schedule
+
+    #[allow(clippy::too_many_arguments)]
+    fn project(
+        rows: &[Row],
+        horizon: u64,
+        scoring_cap: u64,
+        scoring_used: u64,
+        reserve: u64,
+        deposits: u64,
+    ) -> Schedule {
+        project_schedule(
+            rows,
+            100, // current epoch
+            110, // next cycle
+            10,  // cycle length
+            horizon,
+            0,   // min_change: keep everything
+            SOL, // minimum delegation
+            scoring_cap,
+            u64::MAX / 4, // instant cap: irrelevant here
+            scoring_used,
+            0,
+            reserve,
+            deposits,
+        )
+    }
+
+    /// The projection's first epoch must agree with what the program actually does. This is the
+    /// same equivalence check as the target tests, but applied to the projection rather than to
+    /// a single rebalance call.
+    #[test]
+    fn projection_first_epoch_matches_the_program() {
+        let total_pool = 4_000 * SOL;
+        // v0 over target, v1/v2 at target, v3 empty. Target is 1000 SOL.
+        let actives = [1_600 * SOL, 1_000 * SOL, 1_000 * SOL, 0];
+        let reserve = 400 * SOL;
+
+        let (mut state, validators, params) = fixture(&actives);
+        let meta = DirectedStakeMeta::default();
+        let rows = rows_for(&state, &validators, &meta, total_pool, 0);
+        assert_eq!(rows[0].target, 1_000 * SOL);
+
+        let scoring_cap = bps_of(total_pool, params.scoring_unstake_cap_bps);
+        let sched = project(&rows, 1, scoring_cap, 0, reserve, 0);
+
+        // What the program does, one instruction per validator, from the same starting state.
+        let mut bytes = serialize_validator_list(&validators);
+        let list = BigVec { data: &mut bytes };
+        for (index, active) in actives.iter().enumerate() {
+            let program = state
+                .rebalance(
+                    &meta, 100, index, &list, total_pool, reserve, *active, 0, 0, &params,
+                )
+                .expect("rebalance");
+            let projected = sched
+                .changes
+                .iter()
+                .find(|c| c.vote_account == validators[index].vote_account_address.to_string());
+
+            match program {
+                RebalanceType::Increase(lamports) => {
+                    let c = projected.unwrap_or_else(|| {
+                        panic!(
+                            "program increased v{index} by {lamports} but projection had nothing"
+                        )
+                    });
+                    assert!(c.change_sol > 0., "v{index}: sign mismatch");
+                    assert_eq!(
+                        (c.change_sol * 1e9).round() as u64,
+                        lamports,
+                        "v{index}: increase amount"
+                    );
+                }
+                RebalanceType::Decrease(comp) => {
+                    let c = projected.unwrap_or_else(|| {
+                        panic!("program decreased v{index} but projection had nothing")
+                    });
+                    assert!(c.change_sol < 0., "v{index}: sign mismatch");
+                    assert_eq!(
+                        (-c.change_sol * 1e9).round() as u64,
+                        comp.total_unstake_lamports,
+                        "v{index}: decrease amount"
+                    );
+                }
+                RebalanceType::None => assert!(
+                    projected.is_none(),
+                    "program did nothing for v{index} but projection moved it"
+                ),
+            }
+        }
+    }
+
+    /// An exhausted budget stops rotation until the cycle resets, which is the single most
+    /// common reason a validator sees no movement.
+    #[test]
+    fn projection_resumes_only_when_the_cycle_budget_resets() {
+        let actives = [2_000 * SOL, 0];
+        let (state, validators, _) = fixture(&actives);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            2_000 * SOL,
+            0,
+        );
+        let cap = 500 * SOL;
+
+        // Budget fully spent, empty reserve: nothing can move before the reset at epoch 110.
+        let sched = project(&rows, 15, cap, cap, 0, 0);
+        let first = sched
+            .changes
+            .first()
+            .expect("something must eventually move");
+        assert_eq!(
+            first.epoch, 110,
+            "movement must wait for the cycle boundary at 110"
+        );
+        assert!(sched
+            .per_epoch
+            .iter()
+            .filter(|e| e.epoch < 110)
+            .all(|e| e.increased_sol == 0. && e.decreased_sol == 0.));
+        assert!(sched.per_epoch.iter().any(|e| e.cycle_boundary));
+    }
+
+    /// Unstaked lamports are not spendable in the same epoch.
+    #[test]
+    fn projection_delays_funding_by_one_epoch_for_cooldown() {
+        let actives = [2_000 * SOL, 0];
+        let (state, validators, _) = fixture(&actives);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            2_000 * SOL,
+            0,
+        );
+
+        // Ample budget, empty reserve: v0 sheds first, v1 is funded from it the epoch after.
+        let sched = project(&rows, 4, 10_000 * SOL, 0, 0, 0);
+        let decrease = sched
+            .changes
+            .iter()
+            .find(|c| c.change_sol < 0.)
+            .expect("a decrease");
+        let increase = sched
+            .changes
+            .iter()
+            .find(|c| c.change_sol > 0.)
+            .expect("an increase");
+        assert_eq!(
+            increase.epoch,
+            decrease.epoch + 1,
+            "funding must lag the unstake that pays for it by one epoch"
+        );
+    }
+
+    /// With enough horizon and budget, every set member should reach target — no permanent
+    /// shortfall. This is the property whose apparent violation exposed the denominator bug.
+    #[test]
+    fn projection_converges_with_no_permanent_shortfall() {
+        let actives = [3_000 * SOL, 0, 0, 0];
+        let (state, validators, _) = fixture(&actives);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            3_000 * SOL,
+            0,
+        );
+        let target = rows[0].target;
+
+        let sched = project(&rows, 30, 10_000 * SOL, 0, 0, 0);
+
+        for r in &sched.per_validator {
+            let remaining = r.total_due_sol - r.projected_sol;
+            assert!(
+                remaining.abs() < 2.0,
+                "{} still short by {remaining} SOL of target {}",
+                r.vote_account,
+                lamports_to_sol(target)
+            );
+        }
+    }
+
+    /// `--min-change-sol` must drop small movers from the report without distorting the
+    /// queue, which is computed over every validator.
+    #[test]
+    fn projection_filters_small_movers_only_from_the_report() {
+        let actives = [1_010 * SOL, 995 * SOL, 995 * SOL, 1_000 * SOL];
+        let (state, validators, _) = fixture(&actives);
+        let rows = rows_for(
+            &state,
+            &validators,
+            &DirectedStakeMeta::default(),
+            4_000 * SOL,
+            0,
+        );
+
+        let unfiltered = project(&rows, 5, 10_000 * SOL, 0, 100 * SOL, 0);
+        let filtered = project_schedule(
+            &rows,
+            100,
+            110,
+            10,
+            5,
+            50 * SOL, // min_change
+            SOL,
+            10_000 * SOL,
+            u64::MAX / 4,
+            0,
+            0,
+            100 * SOL,
+            0,
+        );
+
+        assert!(!unfiltered.per_validator.is_empty());
+        assert!(
+            filtered.per_validator.is_empty(),
+            "every mover here is under 50 SOL, so none should be reported"
+        );
+        // Per-epoch totals are computed before filtering, so they still show the movement.
+        let unfiltered_moved: f64 = unfiltered.per_epoch.iter().map(|e| e.decreased_sol).sum();
+        let filtered_moved: f64 = filtered.per_epoch.iter().map(|e| e.decreased_sol).sum();
+        assert_eq!(unfiltered_moved, filtered_moved);
+    }
+
+    /// The integration test that would have caught the target-denominator bug: run the real
+    /// `StewardStateV2::rebalance` and confirm the amount it hands out equals the target this
+    /// module computes — and is NOT the larger figure the gross pool would produce.
+    #[test]
+    fn program_target_matches_model_and_nets_out_directed_stake() {
+        let total_pool = 4_000 * SOL;
+        let directed = 400 * SOL;
+        // v0 empty; v1..v3 exactly at the 900 SOL target; remainder sits in the reserve.
+        let actives = [0, 900 * SOL, 900 * SOL, 900 * SOL];
+        let reserve = 1_300 * SOL;
+
+        let (mut state, validators, params) = fixture(&actives);
+        let meta = directed_pool_only(directed);
+        let mut bytes = serialize_validator_list(&validators);
+        let list = BigVec { data: &mut bytes };
+
+        // What the model says the target is.
+        let model_pool = delegatable_pool_lamports(total_pool, directed, 0, actives.len() as u64);
+        let model_target = model_pool / actives.len() as u64;
+        assert_eq!(model_target, 900 * SOL);
+
+        // What the gross pool would have said — the bug.
+        let gross_target = total_pool / actives.len() as u64;
+        assert_eq!(gross_target, 1_000 * SOL);
+
+        // The program is handed the pool net of directed stake, exactly as
+        // instructions/rebalance.rs:259 does it.
+        let undirected_pool = total_pool - meta.total_staked_lamports();
+        let result = state
+            .rebalance(
+                &meta,
+                100,
+                0,
+                &list,
+                undirected_pool,
+                reserve,
+                actives[0],
+                0,
+                0,
+                &params,
+            )
+            .expect("rebalance should succeed");
+
+        match result {
+            RebalanceType::Increase(lamports) => {
+                assert_eq!(
+                    lamports, model_target,
+                    "program funded {lamports} but the model predicted {model_target}"
+                );
+                assert_ne!(
+                    lamports, gross_target,
+                    "program agreed with the gross-pool target, which would mean the directed \
+                     subtraction is not happening where this module thinks it is"
+                );
+            }
+            other => panic!("expected an Increase to target, got {other:?}"),
+        }
+    }
+
+    /// The mirror case: an over-target validator is unstaked down to the model's target, not to
+    /// the gross-pool target.
+    #[test]
+    fn program_unstakes_down_to_the_model_target() {
+        let total_pool = 4_000 * SOL;
+        let directed = 400 * SOL;
+        // v0 over target by 600 SOL; the rest under, so they consume none of the budget.
+        let actives = [1_500 * SOL, 700 * SOL, 700 * SOL, 700 * SOL];
+
+        let (mut state, validators, params) = fixture(&actives);
+        let meta = directed_pool_only(directed);
+        let mut bytes = serialize_validator_list(&validators);
+        let list = BigVec { data: &mut bytes };
+
+        let model_target = delegatable_pool_lamports(total_pool, directed, 0, actives.len() as u64)
+            / actives.len() as u64;
+        let model_excess = actives[0] - model_target;
+        assert_eq!(model_excess, 600 * SOL);
+
+        let undirected_pool = total_pool - meta.total_staked_lamports();
+        let result = state
+            .rebalance(
+                &meta,
+                100,
+                0,
+                &list,
+                undirected_pool,
+                400 * SOL,
+                actives[0],
+                0,
+                0,
+                &params,
+            )
+            .expect("rebalance should succeed");
+
+        match result {
+            RebalanceType::Decrease(components) => {
+                assert_eq!(
+                    components.total_unstake_lamports, model_excess,
+                    "program unstaked {} but the model predicted {model_excess}",
+                    components.total_unstake_lamports
+                );
+                // Categorised as scoring, since internal balances match actuals.
+                assert_eq!(components.scoring_unstake_lamports, model_excess);
+                assert_eq!(components.stake_deposit_unstake_lamports, 0);
+                assert_eq!(components.instant_unstake_lamports, 0);
+            }
+            other => panic!("expected a Decrease to target, got {other:?}"),
+        }
+    }
+
+    /// A validator's own directed stake is excluded from its progress toward target. With 1000
+    /// SOL active of which 400 is directed, the program must see 600 undirected against a 900
+    /// target and INCREASE — the opposite of what it would do if directed stake counted.
+    #[test]
+    fn a_validators_own_directed_stake_does_not_count_toward_its_target() {
+        let total_pool = 4_000 * SOL;
+        let directed = 400 * SOL;
+        let actives = [900 * SOL, 900 * SOL, 900 * SOL, 1_000 * SOL];
+        let directed_index = 3usize;
+
+        let (mut state, validators, params) = fixture(&actives);
+
+        let mut meta = directed_pool_only(directed);
+        // Wire the directed stake to v3 specifically this time.
+        meta.directed_stake_lamports[directed_index] = directed;
+        meta.directed_stake_meta_indices[directed_index] = 0;
+        meta.targets[0].vote_pubkey = validators[directed_index].vote_account_address;
+
+        let mut bytes = serialize_validator_list(&validators);
+        let list = BigVec { data: &mut bytes };
+
+        let model_target = delegatable_pool_lamports(total_pool, directed, 0, actives.len() as u64)
+            / actives.len() as u64;
+        let undirected = actives[directed_index] - directed;
+        assert!(
+            undirected < model_target && actives[directed_index] > model_target,
+            "fixture must be over target on gross stake but under it on undirected stake"
+        );
+        let model_shortfall = model_target - undirected;
+
+        let undirected_pool = total_pool - meta.total_staked_lamports();
+        let result = state
+            .rebalance(
+                &meta,
+                100,
+                directed_index,
+                &list,
+                undirected_pool,
+                400 * SOL,
+                actives[directed_index],
+                0,
+                0,
+                &params,
+            )
+            .expect("rebalance should succeed");
+
+        match result {
+            RebalanceType::Increase(lamports) => assert_eq!(
+                lamports, model_shortfall,
+                "program funded {lamports}, model predicted {model_shortfall}"
+            ),
+            other => panic!(
+                "expected an Increase — directed stake must not count toward target — got {other:?}"
+            ),
+        }
+    }
+
+    /// Regression test for the bug that produced a phantom pool-wide shortfall: targets must
+    /// divide the pool NET of directed stake, matching instructions/rebalance.rs:259.
+    #[test]
+    fn targets_divide_the_undirected_pool() {
+        let total = 9_943_825 * SOL;
+        let directed = 380_068 * SOL;
+        let base = 3_283_000; // minimum_delegation + stake_rent
+        let n_validators = 691;
+        let set_size = 312;
+
+        let pool = delegatable_pool_lamports(total, directed, base, n_validators);
+
+        // Every term must be present. Dropping any one of them was the original bug.
+        assert_eq!(pool, total - directed - base * n_validators);
+
+        let target = pool / set_size;
+        let gross_target = (total - base * n_validators) / set_size;
+
+        // Using the gross pool overstates every target...
+        assert!(gross_target > target);
+        // ...and the aggregate overstatement is the entire directed balance, which is why it
+        // looked like a structural shortfall rather than an arithmetic slip.
+        let aggregate = (gross_target - target) * set_size;
+        assert!(
+            aggregate.abs_diff(directed) < set_size,
+            "aggregate overstatement {aggregate} should equal directed total {directed} \
+             up to integer-division rounding"
+        );
+
+        // Ballpark guard so a units error (lamports vs SOL) still fails loudly.
+        assert!((30_000..31_000).contains(&(target / SOL)));
+    }
+
+    #[test]
+    fn zero_directed_stake_leaves_the_pool_unchanged() {
+        let total = 1_000_000 * SOL;
+        let base = 3_283_000;
+        assert_eq!(
+            delegatable_pool_lamports(total, 0, base, 100),
+            total - base * 100
+        );
+    }
+
+    #[test]
+    fn delegatable_pool_saturates_rather_than_underflowing() {
+        // Directed larger than the pool is nonsensical, but must not panic.
+        assert_eq!(delegatable_pool_lamports(10, 999, 1, 5), 0);
+    }
+
+    #[test]
+    fn funded_within_this_cycle_is_floored_at_one_epoch() {
+        // Supply already covers the need, so the only wait is cooldown.
+        assert_eq!(epochs_until_funded(100, 1_000, 5_000, 8, 10), Some(1));
+    }
+
+    #[test]
+    fn zero_need_returns_zero() {
+        assert_eq!(epochs_until_funded(0, 0, 0, 8, 10), Some(0));
+    }
+
+    #[test]
+    fn spills_into_the_next_cycle() {
+        // 1_500 needed, 500 available now, 1_000 per future cycle -> exactly one future cycle,
+        // so funding lands when the budget resets.
+        assert_eq!(epochs_until_funded(1_500, 500, 1_000, 8, 10), Some(8));
+    }
+
+    #[test]
+    fn spills_across_multiple_cycles() {
+        // 2_500 needed, 500 now, 1_000 per cycle -> 2 future cycles: reset + one full cycle.
+        assert_eq!(epochs_until_funded(2_500, 500, 1_000, 8, 10), Some(18));
+        // 3_500 needed -> 3 future cycles.
+        assert_eq!(epochs_until_funded(3_500, 500, 1_000, 8, 10), Some(28));
+    }
+
+    #[test]
+    fn no_supply_means_no_estimate() {
+        assert_eq!(epochs_until_funded(1_000, 0, 0, 8, 10), None);
+    }
+
+    #[test]
+    fn exhausted_budget_and_empty_reserve_is_reported_as_such() {
+        let row = Row {
+            vote_account: Pubkey::new_unique(),
+            in_set: true,
+            active: 0,
+            marked_instant_unstake: false,
+            raw_rank: None,
+            denominator: 1,
+            rank: Some(5),
+            current: 0,
+            directed: 0,
+            transient: 0,
+            target: 1_000_000_000,
+        };
+        assert_eq!(
+            classify(Some(&row), 1_000_000, 0, 0, 500_000_000),
+            LimitingFactor::ScoringChurnBudgetExhausted
+        );
+    }
+
+    #[test]
+    fn in_flight_stake_reports_cooldown() {
+        let row = Row {
+            vote_account: Pubkey::new_unique(),
+            in_set: true,
+            active: 0,
+            marked_instant_unstake: false,
+            raw_rank: None,
+            denominator: 1,
+            rank: Some(5),
+            current: 0,
+            directed: 0,
+            transient: 500_000_000,
+            target: 1_000_000_000,
+        };
+        assert_eq!(
+            classify(Some(&row), 1_000_000, 0, 0, 0),
+            LimitingFactor::AwaitingCooldown
+        );
+    }
+
+    #[test]
+    fn at_target_within_minimum_delegation() {
+        let row = Row {
+            vote_account: Pubkey::new_unique(),
+            in_set: true,
+            active: 0,
+            marked_instant_unstake: false,
+            raw_rank: None,
+            denominator: 1,
+            rank: Some(5),
+            current: 999_500_000,
+            directed: 0,
+            transient: 0,
+            target: 1_000_000_000,
+        };
+        assert_eq!(
+            classify(Some(&row), 1_000_000, 100, 100, 0),
+            LimitingFactor::AtTarget
+        );
+    }
+
+    #[test]
+    fn nobody_ahead_and_reserve_funded_means_next_rebalance() {
+        let row = Row {
+            vote_account: Pubkey::new_unique(),
+            in_set: true,
+            active: 0,
+            marked_instant_unstake: false,
+            raw_rank: None,
+            denominator: 1,
+            rank: Some(0),
+            current: 0,
+            directed: 0,
+            transient: 0,
+            target: 1_000_000_000,
+        };
+        // Top of the queue with a funded reserve: not "blocked by queue position".
+        assert_eq!(
+            classify(Some(&row), 1_000_000, 10_000_000_000, 5_000_000_000, 0),
+            LimitingFactor::NextRebalance
+        );
+    }
+
+    /// `sol_ahead` must be derived from rank, not from position within the under-target list,
+    /// or an at-target validator sums the entire list and reports the pool-wide shortfall.
+    #[test]
+    fn ahead_of_rank_ignores_lower_ranked_validators() {
+        let shortfalls = [(0usize, 100u64), (5, 200), (10, 400)];
+        let ahead_of = |rank: usize| -> u64 {
+            shortfalls
+                .iter()
+                .filter(|(r, _)| *r < rank)
+                .map(|(_, s)| *s)
+                .sum()
+        };
+        assert_eq!(ahead_of(0), 0);
+        assert_eq!(ahead_of(5), 100);
+        assert_eq!(ahead_of(10), 300);
+        // A validator ranked between the entries still only counts those above it.
+        assert_eq!(ahead_of(7), 300);
+    }
+
+    #[test]
+    fn queue_position_when_others_are_ahead() {
+        let row = Row {
+            vote_account: Pubkey::new_unique(),
+            in_set: true,
+            active: 0,
+            marked_instant_unstake: false,
+            raw_rank: None,
+            denominator: 1,
+            rank: Some(200),
+            current: 0,
+            directed: 0,
+            transient: 0,
+            target: 1_000_000_000,
+        };
+        // Budget and reserve both have room, but 500 SOL is queued ahead of only 1 SOL of reserve.
+        assert_eq!(
+            classify(
+                Some(&row),
+                1_000_000,
+                10_000_000_000,
+                1_000_000_000,
+                500_000_000_000
+            ),
+            LimitingFactor::QueuePosition
+        );
+    }
+}

--- a/utils/steward-cli/src/commands/info/view_stake_eta.rs
+++ b/utils/steward-cli/src/commands/info/view_stake_eta.rs
@@ -404,7 +404,14 @@ pub struct ScheduleSummaryRow {
     pub rank: Option<usize>,
     pub in_delegation_set: bool,
     pub direction: String,
+    /// Undirected balance — what the target is measured against.
     pub current_sol: f64,
+    /// Directed stake, excluded from `current_sol` and from the target calculation. A validator
+    /// can therefore show a large shortfall while holding far more than target in total, so this
+    /// must be surfaced alongside `current_sol` or the row reads as misleadingly underfunded.
+    pub directed_sol: f64,
+    /// Everything the validator actually holds, directed included.
+    pub total_stake_sol: f64,
     pub target_sol: f64,
     /// Total movement still due to reach target, regardless of horizon
     pub total_due_sol: f64,
@@ -664,6 +671,8 @@ fn project_schedule(
                     "decrease".to_string()
                 },
                 current_sol: lamports_to_sol(rows[i].current),
+                directed_sol: lamports_to_sol(rows[i].directed),
+                total_stake_sol: lamports_to_sol(rows[i].active),
                 target_sol: lamports_to_sol(s.target),
                 total_due_sol: total_due[i] as f64 / 1e9,
                 projected_sol: projected[i] as f64 / 1e9,
@@ -1205,8 +1214,16 @@ fn print_schedule(s: &Schedule) {
 
     println!("\n━━━ Per-validator rollup ━━━");
     println!(
-        "  {:<44} {:>5} {:>11} {:>11} {:>11} {:>11} {:>7} {:>6}",
-        "vote account", "rank", "current", "target", "total due", "projected", "epochs", "done"
+        "  {:<44} {:>5} {:>11} {:>11} {:>11} {:>11} {:>11} {:>7} {:>6}",
+        "vote account",
+        "rank",
+        "undirected",
+        "directed",
+        "target",
+        "total due",
+        "projected",
+        "epochs",
+        "done"
     );
     for r in &s.per_validator {
         let epochs = match (r.first_epoch, r.last_epoch) {
@@ -1215,10 +1232,11 @@ fn print_schedule(s: &Schedule) {
             _ => "none".to_string(),
         };
         println!(
-            "  {:<44} {:>5} {:>11.0} {:>11.0} {:>+11.0} {:>+11.0} {:>7} {:>6}{}",
+            "  {:<44} {:>5} {:>11.0} {:>11.0} {:>11.0} {:>+11.0} {:>+11.0} {:>7} {:>6}{}{}",
             r.vote_account,
             r.rank.map(|x| x.to_string()).unwrap_or("—".to_string()),
             r.current_sol,
+            r.directed_sol,
             r.target_sol,
             r.total_due_sol,
             r.projected_sol,
@@ -1228,6 +1246,12 @@ fn print_schedule(s: &Schedule) {
                 ""
             } else {
                 "  [not in set]"
+            },
+            // Without this a directed-heavy validator reads as the most underfunded in the pool.
+            if r.directed_sol > 0. {
+                format!("  [holds {:.0} SOL in total]", r.total_stake_sol)
+            } else {
+                String::new()
             },
         );
     }

--- a/utils/steward-cli/src/commands/info/view_stake_eta.rs
+++ b/utils/steward-cli/src/commands/info/view_stake_eta.rs
@@ -13,6 +13,28 @@ use stakenet_sdk::utils::accounts::{get_all_steward_accounts, get_directed_stake
 
 use crate::commands::command_args::ViewStakeEta;
 
+/// Standing caveat attached to every result, in both the human and JSON output.
+///
+/// The deterministic inputs — eligibility, target, rank, queue position, remaining budget — are
+/// only half of what decides when stake arrives. The other half is not predictable: deposit and
+/// withdrawal flow, changes in this and other validators' performance and commissions,
+/// instant-unstake events elsewhere, and the re-scoring that happens at every cycle boundary.
+/// Anyone sharing this output needs the caveat travelling with it, or a projection gets read as
+/// a promise.
+const DISCLAIMER: &[&str] = &[
+    "This is NOT a guarantee of stake and NOT a commitment from Jito. It is a projection of \
+     today's conditions, and conditions move.",
+    "Firm — read directly from on-chain state: whether you are eligible, your 1/N target, your \
+     rank, the SOL queued ahead of you, and how much churn budget is left this cycle.",
+    "Reasonable — what you would receive next epoch given the reserve exactly as it stands now.",
+    "Speculative — anything past the next cycle boundary. The set is re-scored, N changes, and \
+     every target moves with pool TVL.",
+    "Not modelled at all — the rate of deposits and withdrawals to the pool, changes in your own \
+     or other validators' performance and commissions, and instant-unstake events elsewhere.",
+    "A projection 10 or 20 epochs out can differ substantially from what actually happens. Do \
+     not present it to a validator as an expectation.",
+];
+
 /// Why a validator is not yet at its target share. Mirrors the enum in the
 /// validator-facing spec so the UI can map each variant to plain language.
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Clone, Copy)]
@@ -172,6 +194,12 @@ pub struct StakeEtaOutput {
     /// Populated when --schedule-epochs is set
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub schedule: Option<Schedule>,
+    /// Always populated. Serialized so a consumer that renders this output cannot silently drop
+    /// the caveat — a projection presented without it reads as a promise.
+    pub disclaimer: Vec<String>,
+    /// Epoch past which the projection is illustrative rather than meaningful, because the
+    /// delegation set is re-scored at that boundary.
+    pub speculative_beyond_epoch: u64,
 }
 
 /// One validator's position relative to its target
@@ -1127,6 +1155,8 @@ pub async fn command_view_stake_eta(
         most_over_target,
         largest_directed_holders,
         schedule,
+        disclaimer: DISCLAIMER.iter().map(|s| s.to_string()).collect(),
+        speculative_beyond_epoch: state.next_cycle_epoch,
     };
 
     if print_json {
@@ -1178,11 +1208,15 @@ fn print_lines(title: &str, lines: &[ValidatorLine]) {
     }
 }
 
-fn print_schedule(s: &Schedule) {
+fn print_schedule(s: &Schedule, speculative_beyond_epoch: u64) {
     println!(
         "\n━━━ Expected stake change by epoch — next {} epochs, changes ≥ {:.0} SOL ━━━",
         s.horizon_epochs, s.min_change_sol
     );
+    println!(
+        "  Rows at or past epoch {speculative_beyond_epoch} are marked (?): the set is re-scored there,"
+    );
+    println!("  so treat them as illustrative of the mechanism, not as a forecast.");
     if s.per_validator.is_empty() {
         println!("  No validator has a change of that size due.");
         return;
@@ -1201,7 +1235,7 @@ fn print_schedule(s: &Schedule) {
             last_epoch = c.epoch;
         }
         println!(
-            "  {:<8} {:>5} {:<44} {:>+12.0} {:>13.0} {:>12.0}  {}",
+            "  {:<8} {:>5} {:<44} {:>+12.0} {:>13.0} {:>12.0}  {}{}",
             c.epoch,
             c.rank.map(|r| r.to_string()).unwrap_or("—".to_string()),
             c.vote_account,
@@ -1209,6 +1243,11 @@ fn print_schedule(s: &Schedule) {
             c.balance_after_sol,
             c.target_sol,
             c.direction,
+            if c.epoch >= speculative_beyond_epoch {
+                " (?)"
+            } else {
+                ""
+            },
         );
     }
 
@@ -1273,6 +1312,8 @@ fn print_schedule(s: &Schedule) {
             e.scoring_budget_remaining_sol,
             if e.cycle_boundary {
                 "   ← new cycle, budgets reset & set re-scored"
+            } else if e.epoch >= speculative_beyond_epoch {
+                "   (?)"
             } else {
                 ""
             },
@@ -1285,7 +1326,33 @@ fn print_schedule(s: &Schedule) {
     }
 }
 
+/// Printed at both the top and the bottom of the output: a long schedule scrolls the top away,
+/// and this is the one part that must not be missed.
+fn print_disclaimer(o: &StakeEtaOutput, heading: &str) {
+    println!("\n┏━━ {heading} ━━");
+    for line in &o.disclaimer {
+        // Wrap by hand so the banner stays readable in an 80-column terminal.
+        let mut col = 0;
+        print!("┃ ");
+        for word in line.split_whitespace() {
+            if col + word.len() + 1 > 92 {
+                print!("\n┃   ");
+                col = 2;
+            }
+            print!("{word} ");
+            col += word.len() + 1;
+        }
+        println!();
+    }
+    println!(
+        "┃ Projection is illustrative only beyond epoch {}, when the set is re-scored.",
+        o.speculative_beyond_epoch
+    );
+    println!("┗━━");
+}
+
 fn print_human(o: &StakeEtaOutput) {
+    print_disclaimer(o, "READ THIS FIRST — this does not guarantee stake");
     println!("\n━━━ Pool (epoch {}) ━━━", o.as_of_epoch);
     println!("  TVL:                    {:>14.0} SOL", o.pool.tvl_sol);
     println!(
@@ -1374,7 +1441,7 @@ fn print_human(o: &StakeEtaOutput) {
     }
 
     if let Some(sched) = &o.schedule {
-        print_schedule(sched);
+        print_schedule(sched, o.speculative_beyond_epoch);
     }
 
     if let (Some(p), Some(e)) = (&o.position, &o.eta) {
@@ -1418,6 +1485,8 @@ fn print_human(o: &StakeEtaOutput) {
         );
         println!("  re-derived at each cycle boundary.");
     }
+
+    print_disclaimer(o, "REMINDER — this does not guarantee stake");
     println!();
 }
 

--- a/utils/steward-cli/src/main.rs
+++ b/utils/steward-cli/src/main.rs
@@ -35,7 +35,8 @@ use commands::{
         view_directed_stake_tickets::command_view_directed_stake_tickets,
         view_directed_stake_whitelist::command_view_directed_stake_whitelist,
         view_next_index_to_remove::command_view_next_index_to_remove,
-        view_priority_fee_config::command_view_priority_fee_config, view_state::command_view_state,
+        view_priority_fee_config::command_view_priority_fee_config,
+        view_stake_eta::command_view_stake_eta, view_state::command_view_state,
     },
     init::{init_steward::command_init_steward, realloc_state::command_realloc_state},
 };
@@ -113,6 +114,9 @@ async fn main() -> Result<()> {
         Commands::ViewState(args) => command_view_state(args, &client, steward_program_id).await,
         Commands::ViewNextIndexToRemove(args) => {
             command_view_next_index_to_remove(args, &client, steward_program_id).await
+        }
+        Commands::ViewStakeEta(args) => {
+            command_view_stake_eta(args, &client, steward_program_id).await
         }
         Commands::ViewBlacklist(args) => {
             command_view_blacklist(


### PR DESCRIPTION
## Problem

Validators can already see **whether** they are eligible on the [steward page](https://www.jito.network/stakenet/steward/). What they cannot see is *when to expect stake*, or — if they are in the set but below target — *why nothing is happening*.

The premise that this can't be answered programmatically turns out to be too strong. The wait is deterministic in almost every input; only the arrival date depends on exogenous deposit flow.

## What this adds

`steward-cli view-stake-eta` answers it from public on-chain state, with no program or governance change. Four accounts in one `getMultipleAccounts`.

Increases are funded from the reserve in **descending score order**, so a validator's wait is driven by the cumulative shortfall of everyone ranked above it, and by how much rotation budget is left in the cycle (`scoring_unstake_cap_bps`, reset every `num_epochs_between_scoring` epochs). The command reports rank, SOL ahead in the queue, remaining budget and its reset epoch, and a confidence-banded ETA — led by a `limiting_factor` that names the actual blocker (`queue_position`, `scoring_churn_budget_exhausted`, `reserve_empty`, `next_rebalance`, …) rather than just an epoch count.

Two extra modes:

- `--top N` — the validators furthest over target, and the largest holders of directed stake. Directed stake is excluded from algorithmic targets, so this makes clear how much of the pool's apparent excess is directed and therefore *not* algorithmically reducible.
- `--schedule-epochs N` — projects movement forward, replaying the program's ordering rules: decreases lowest-raw-score first against the cycle budgets, increases highest-score first out of the reserve, one epoch of cooldown between them. `--min-change-sol` drops the long tail of trivial adjustments.

## The subtlety worth reviewing

Targets divide the pool **net of directed stake**, matching `instructions/rebalance.rs:259`. Dividing the gross pool instead overstates every target by `directed_total / N` — currently ~1,218 SOL per validator — which aggregates into a phantom pool-wide shortfall equal to the entire directed balance, and looks convincingly like a structural problem rather than an arithmetic slip. An earlier draft of this work made exactly that error.

Because the failure mode is a *silently plausible wrong number* rather than a crash, an unreadable `DirectedStakeMeta` is now fatal rather than defaulting to zero directed stake. `--assume-no-directed-stake` overrides it for deployments that genuinely have none.

## Docs

`utils/steward-cli/STAKE_ETA.md` documents the model — why arrival is a queue rather than a schedule, the exact inputs, the output schema, the reconciliation invariant, and the known limitations. Linked from the CLI README with a note to read it before changing the estimator.

## Testing

28 unit tests. Four drive the real `StewardStateV2::rebalance` and assert the program's own increase/decrease amounts match the model:

- the program funds an empty validator to exactly the model's target, and *not* the gross-pool figure
- an over-target validator is unstaked by exactly the model's excess, in the `scoring` category
- a validator's own directed stake does not count toward its target (opposite sign to what it would be if it did, so it cannot pass by accident)
- the projection's first epoch reproduces the program instruction-for-instruction

Coverage alone proves little, so each of these faults was injected deliberately and confirmed to fail tests:

| Injected fault | Tests killed |
| :- | -: |
| Drop the directed-stake subtraction | 5 |
| Derive rank from index order, not score order | 2 |
| Remove the one-epoch cooldown | 2 |
| Never reset the cycle budget at the boundary | 1 |
| Ignore the minimum-delegation floor when queueing | 1 |

## Known limitations

Documented in STAKE_ETA.md §8 rather than left implicit:

- Deposit flow is exogenous and is the dominant uncertainty; the low bound assumes none, and the optimistic bound is operator-supplied via `--deposit-rate-sol` rather than derived from keeper metrics yet.
- Multi-epoch projection beyond the first epoch is property-tested (cycle reset, cooldown, convergence) rather than verified against the program, which would need a stake-pool simulator applying transient stake between epochs.
- Within a cycle the unstake budget is not rate-limited per epoch, so the projection spends it as soon as a cycle opens. Per-cycle totals are reliable; the exact epoch within a cycle is indicative, since real timing depends on when cranks run.
- Any estimate crossing a cycle boundary assumes the set and N are unchanged; both are re-derived at each boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)