### PR TITLE
fix: enforce owner check on priority fee distribution account (#293)

### DIFF
--- a/programs/validator-history/src/instructions/copy_priority_fee_distribution.rs
+++ b/programs/validator-history/src/instructions/copy_priority_fee_distribution.rs
@@ -41,6 +41,7 @@ pub struct CopyPriorityFeeDistribution<'info> {
         ],
         bump,
         seeds::program = config.priority_fee_distribution_program.key(),
+        owner = config.priority_fee_distribution_program.key()
     )]
     pub distribution_account: UncheckedAccount<'info>,
 

--- a/tests/tests/validator_history/test_copy_priority_fee_distribution.rs
+++ b/tests/tests/validator_history/test_copy_priority_fee_distribution.rs
@@ -14,7 +14,12 @@ use validator_history::{Config, MerkleRootUploadAuthority, ValidatorHistory};
 const TIP_ROUTER_AUTHORITY: Pubkey = pubkey!("8F4jGUmxF36vQ6yabnsxX6AQVXdKBhs8kGSUuRKSg8Xt");
 
 #[tokio::test]
-async fn test_priority_fee_distribution_account_does_not_exist() {
+async fn test_priority_fee_distribution_account_does_not_exist_fails() {
+    // Prior to the `owner` constraint on `distribution_account`, calling this instruction
+    // before the real distribution account was created would silently succeed and record a
+    // permanent `DNE` entry (see `PriorityFeeDistributionAccountAlreadyCopied`), poisoning
+    // validator history for that epoch. It must now fail instead, matching the equivalent
+    // uninitialized-account case for `copy_tip_distribution_account` (test_mev_commission_fail).
     let fixture = TestFixture::new().await;
     let ctx = &fixture.ctx;
     fixture.initialize_config().await;
@@ -51,19 +56,9 @@ async fn test_priority_fee_distribution_account_does_not_exist() {
         &[&fixture.keypair],
         blockhash,
     );
-    fixture.submit_transaction_assert_success(transaction).await;
-
-    let account: ValidatorHistory = fixture
-        .load_and_deserialize(&fixture.validator_history_account)
+    fixture
+        .submit_transaction_assert_error(transaction, "ConstraintOwner")
         .await;
-    assert!(account.history.idx == 0);
-    assert!(account.history.arr[0].epoch == 0);
-    assert!(account.history.arr[0].priority_fee_commission == 0);
-    assert!(account.history.arr[0].priority_fee_tips == 0);
-    assert!(
-        account.history.arr[0].priority_fee_merkle_root_upload_authority
-            == MerkleRootUploadAuthority::DNE
-    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Fixes #293.

`CopyPriorityFeeDistribution` validates `distribution_account`'s PDA seeds but never checks its **owner**, unlike the equivalent `tip_distribution_account` check in `CopyTipDistributionAccount` (which already has `owner = config.tip_distribution_program.key()`).

Because the check was missing, anyone could call this instruction with the correct PDA address *before* the real `PriorityFeeDistributionAccount` was created for that validator/epoch. Deserialization then fails, the handler falls through to `unwrap_or(default)`, and a `DNE` entry gets written permanently — `PriorityFeeDistributionAccountAlreadyCopied` then blocks any later correction once the real account does exist, poisoning validator history for that epoch.

## Fix

Add `owner = config.priority_fee_distribution_program.key()` to `distribution_account`, matching the pattern already used by the tip-distribution sibling instruction. The instruction now fails fast (`ConstraintOwner`) instead of silently recording a poisoned default when the distribution account doesn't exist yet.

## Test plan

- Updated `test_priority_fee_distribution_account_does_not_exist` → `test_priority_fee_distribution_account_does_not_exist_fails`, asserting `ConstraintOwner` instead of a successful DNE write (mirrors `test_mev_commission_fail` for the tip-distribution sibling).
- Ran the full `test_copy_priority_fee_distribution` suite locally (`cargo build-sbf` + `cargo test`): all 6 tests pass, including the pre-existing success-path and double-copy tests, confirming legitimate flows are unaffected.

## One thing worth flagging

The keeper (`priority_fee_commission.rs::update_priority_fee_commission`) sends this instruction for every validator/epoch where the local entry is `Unset`, without pre-checking the distribution account exists on-chain. After this fix, a validator whose distribution account is never created will get a failing (retried) instruction each crank run instead of a one-time `DNE` write. This mirrors the tip-distribution keeper's existing "always attempt, let failures retry" design, so it's consistent with how the codebase already handles the sibling case — but flagging it in case the DNE-recording behavior was intentionally relied on for `steward` scoring somewhere.